### PR TITLE
feat: huntr wishlist + auto-detect board

### DIFF
--- a/src/commands/huntr.ts
+++ b/src/commands/huntr.ts
@@ -35,7 +35,6 @@ interface HuntrJob {
   rootDomain?: string;
   htmlDescription?: string;
   _list?: string;   // which list (wishlist, applied, etc.) this job belongs to
-  _board?: string;  // which board this job belongs to
   _company?: string;
   company?: HuntrCompany;
 }


### PR DESCRIPTION
## Summary

- Adds `job-shit huntr wishlist` — shows only jobs in your Huntr Wishlist (the ones you haven't applied to yet). Filters by matching list name "Wishlist" via the `/board/:id/lists` endpoint, the same way huntr-cli determines stages.
- `job-shit huntr tailor <jobId>` no longer requires `--board`. If omitted it searches all your active boards for the job and picks up the board ID from the job object itself.
- `job-shit huntr jobs` now shows which list each job is in alongside the title.

## The workflow this enables

```bash
# See what's in your wishlist
job-shit huntr wishlist

# Pick one, tailor it — no board ID needed
job-shit huntr tailor abc123
```

## Notes

- `huntr-cli` has no library exports so types/HTTP client remain inlined (same approach as before, extended with `_list`, `_board`, `HuntrBoardList`)
- Board auto-detection fetches jobs from each board sequentially until it finds the job — fine for a personal tool with 1-2 boards

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (21 tests)
- [ ] `job-shit huntr wishlist` shows only wishlist-stage jobs
- [ ] `job-shit huntr tailor <jobId>` works without `--board`

🤖 Generated with [Claude Code](https://claude.com/claude-code)