### PR TITLE
[codex] Improve tailoring fidelity and add HTML resume rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "keytar": "^7.9.0",
-        "openai": "^6.27.0"
+        "marked": "^17.0.4"
       },
       "bin": {
         "job-shit": "dist/cli.js"
@@ -2287,6 +2287,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -2405,27 +2417,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/openai": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.27.0.tgz",
-      "integrity": "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "keytar": "^7.9.0",
-    "openai": "^6.27.0"
+    "marked": "^17.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/commands/huntr.ts
+++ b/src/commands/huntr.ts
@@ -2,9 +2,10 @@ import { Command } from 'commander';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { loadConfig, resolveHuntrToken } from '../config.js';
-import { createOpenAIClient } from '../lib/ai.js';
+import { createAnthropicClient } from '../lib/ai.js';
 import { tailorDocuments } from '../lib/tailor.js';
 import { findFile, readFile, JOB_SHIT_DIR } from '../lib/files.js';
+import { renderResumeHtml } from '../lib/render.js';
 
 // ---------------------------------------------------------------------------
 // Huntr API types (inlined — huntr-cli has no library exports)
@@ -348,7 +349,7 @@ export function registerHuntrCommand(program: Command): void {
       console.log(`Using bio:    ${bioPath}`);
 
       const config = loadConfig();
-      const aiClient = createOpenAIClient(config.apiKey);
+      const aiClient = createAnthropicClient(config.apiKey);
 
       await tailorAndWrite({ job, resume, bio, baseCoverLetter, resumeSupplemental, aiClient, model: config.model, outputDir: opts.output });
     });
@@ -401,7 +402,7 @@ export function registerHuntrCommand(program: Command): void {
       console.log(`Found ${wishlistJobs.length} wishlist job(s). Tailoring...\n`);
 
       const config = loadConfig();
-      const aiClient = createOpenAIClient(config.apiKey);
+      const aiClient = createAnthropicClient(config.apiKey);
 
       let done = 0;
       let failed = 0;
@@ -467,7 +468,7 @@ async function tailorAndWrite(args: {
   bio: string;
   baseCoverLetter?: string;
   resumeSupplemental?: string;
-  aiClient: Awaited<ReturnType<typeof createOpenAIClient>>;
+  aiClient: Awaited<ReturnType<typeof createAnthropicClient>>;
   model: string;
   outputDir: string;
 }): Promise<void> {
@@ -504,6 +505,10 @@ async function tailorAndWrite(args: {
   writeFileSync(resumeOut, output.resume, 'utf8');
   writeFileSync(coverLetterOut, output.coverLetter, 'utf8');
 
+  const resumeHtmlOut = join(outputDir, `resume-${slug}.html`);
+  writeFileSync(resumeHtmlOut, renderResumeHtml(output.resume, `Resume — ${companyName}`), 'utf8');
+
   console.log(`    ✓ resume       → ${resumeOut}`);
+  console.log(`    ✓ resume (html)→ ${resumeHtmlOut}`);
   console.log(`    ✓ cover letter → ${coverLetterOut}`);
 }

--- a/src/commands/tailor.ts
+++ b/src/commands/tailor.ts
@@ -2,9 +2,10 @@ import { Command } from 'commander';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { loadConfig } from '../config.js';
-import { createOpenAIClient } from '../lib/ai.js';
+import { createAnthropicClient } from '../lib/ai.js';
 import { tailorDocuments } from '../lib/tailor.js';
 import { findFile, readFile, JOB_SHIT_DIR } from '../lib/files.js';
+import { renderResumeHtml } from '../lib/render.js';
 function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
@@ -78,7 +79,7 @@ export function registerTailorCommand(program: Command): void {
       } catch { /* optional */ }
 
       const config = loadConfig();
-      const client = createOpenAIClient(config.apiKey);
+      const client = createAnthropicClient(config.apiKey);
 
       console.log(`\nUsing resume: ${resumePath}`);
       console.log(`Using bio:    ${bioPath}`);
@@ -106,7 +107,11 @@ export function registerTailorCommand(program: Command): void {
       writeFileSync(resumeOut, output.resume, 'utf8');
       writeFileSync(coverLetterOut, output.coverLetter, 'utf8');
 
+      const resumeHtmlOut = join(opts.output, `resume-${slug}.html`);
+      writeFileSync(resumeHtmlOut, renderResumeHtml(output.resume, `Resume — ${opts.company}`), 'utf8');
+
       console.log(`✓ Tailored resume   → ${resumeOut}`);
+      console.log(`✓ Resume (HTML)     → ${resumeHtmlOut}`);
       console.log(`✓ Cover letter      → ${coverLetterOut}`);
     });
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 
-export function createOpenAIClient(apiKey: string): Anthropic {
+export function createAnthropicClient(apiKey: string): Anthropic {
   return new Anthropic({ apiKey });
 }
 

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -1,0 +1,266 @@
+import { Marked } from 'marked';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function looksLikeDate(html: string): boolean {
+  return /^\d{4}/.test(html.replace(/<[^>]*>/g, '').trim());
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a custom marked Renderer with stateful class injection.
+ * Tracks position in the document (header area, h3 context) to apply
+ * semantic CSS classes that drive the typographic hierarchy.
+ */
+function makeRenderer() {
+  // State shared across renderer calls (in document order)
+  let prevToken = '';
+  let h2Count = 0;
+
+  return {
+    heading({ text, depth }: { text: string; depth: number }): string {
+      if (depth === 1) {
+        h2Count = 0;
+        prevToken = 'h1';
+        return `<h1>${text}</h1>\n`;
+      }
+      if (depth === 2) {
+        const isRole = h2Count === 0;
+        h2Count++;
+        prevToken = isRole ? 'role-h2' : 'section-h2';
+        return `<h2 class="${isRole ? 'role' : 'section'}">${text}</h2>\n`;
+      }
+      if (depth === 3) {
+        prevToken = 'h3';
+        return `<h3>${text}</h3>\n`;
+      }
+      prevToken = `h${depth}`;
+      return `<h${depth}>${text}</h${depth}>\n`;
+    },
+
+    paragraph({ text }: { text: string }): string {
+      const prev = prevToken;
+      if (prev === 'role-h2') {
+        prevToken = 'contact';
+        return `<p class="contact">${text}</p>\n`;
+      }
+      if (prev === 'contact') {
+        prevToken = 'links';
+        return `<p class="links">${text}</p>\n`;
+      }
+      if (prev === 'h3' && looksLikeDate(text)) {
+        prevToken = 'date';
+        return `<p class="date">${text}</p>\n`;
+      }
+      prevToken = 'p';
+      return `<p>${text}</p>\n`;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CSS
+// ---------------------------------------------------------------------------
+
+const CSS = `
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html { font-size: 16px; }
+
+  body {
+    font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+    background: #fff;
+    color: #1f1f1f;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  .resume {
+    max-width: 780px;
+    margin: 0 auto;
+    padding: 80px 72px;
+  }
+
+  /* ── Name ─────────────────────────────────────── */
+
+  h1 {
+    font-size: 46px;
+    font-weight: 700;
+    letter-spacing: -0.035em;
+    color: #0a0a0a;
+    line-height: 1;
+    margin-bottom: 10px;
+  }
+
+  /* ── Role subtitle ────────────────────────────── */
+
+  h2.role {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: #aaa;
+    margin-bottom: 22px;
+  }
+
+  /* ── Contact / Links ──────────────────────────── */
+
+  p.contact {
+    font-size: 11.5px;
+    color: #888;
+    letter-spacing: 0.01em;
+    line-height: 1.6;
+    margin-bottom: 4px;
+  }
+
+  p.links {
+    font-size: 11px;
+    color: #c0c0c0;
+    letter-spacing: 0.01em;
+    line-height: 1.6;
+    margin-bottom: 64px;
+  }
+
+  /* ── Section headers ──────────────────────────── */
+
+  h2.section {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: #c0c0c0;
+    margin-top: 56px;
+    margin-bottom: 20px;
+  }
+
+  /* ── Job / entry titles ───────────────────────── */
+
+  h3 {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: #0a0a0a;
+    letter-spacing: -0.01em;
+    line-height: 1.25;
+    margin-top: 28px;
+    margin-bottom: 3px;
+  }
+
+  h2.section + h3 { margin-top: 0; }
+
+  /* ── Dates ────────────────────────────────────── */
+
+  p.date {
+    font-size: 10.5px;
+    color: #bbb;
+    letter-spacing: 0.05em;
+    line-height: 1;
+    margin-bottom: 10px;
+  }
+
+  /* ── Bullet lists ─────────────────────────────── */
+
+  ul { list-style: none; padding: 0; margin: 0; }
+
+  li {
+    font-size: 13px;
+    line-height: 1.7;
+    color: #2a2a2a;
+    padding-left: 18px;
+    position: relative;
+    margin-bottom: 5px;
+  }
+
+  li:last-child { margin-bottom: 0; }
+
+  li::before {
+    content: '—';
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: #ddd;
+    font-weight: 300;
+    font-size: 12px;
+  }
+
+  /* ── Body text ────────────────────────────────── */
+
+  p {
+    font-size: 13px;
+    line-height: 1.7;
+    color: #2a2a2a;
+    margin-bottom: 8px;
+  }
+
+  /* Summary / Education (first p after section header) */
+  h2.section + p {
+    font-size: 13.5px;
+    line-height: 1.75;
+    color: #333;
+  }
+
+  /* Skills content (p after h3 that isn't a date) */
+  h3 + p:not(.date) {
+    font-size: 12.5px;
+    color: #555;
+    line-height: 1.75;
+    margin-top: 2px;
+  }
+
+  /* ── Links ────────────────────────────────────── */
+
+  a { color: inherit; text-decoration: none; }
+
+  /* ── Print ────────────────────────────────────── */
+
+  @media print {
+    @page { margin: 0.5in 0.6in; size: letter portrait; }
+    body { background: white; print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    .resume { padding: 0; max-width: 100%; }
+    h2.section { break-after: avoid; page-break-after: avoid; }
+    h3 { break-after: avoid; page-break-after: avoid; }
+    li { break-inside: avoid; page-break-inside: avoid; }
+    p.contact, p.links { break-after: avoid; page-break-after: avoid; }
+  }
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a tailored resume (markdown) to a styled, print-ready HTML string.
+ * Open the file in Chrome and Cmd+P → Save as PDF.
+ */
+export function renderResumeHtml(markdown: string, pageTitle = 'Resume'): string {
+  const cleaned = markdown
+    .replace(/<!--[\s\S]*?-->/g, '')   // strip AI-only HTML comments
+    .replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, '[$1](mailto:$1)')  // email autolinks
+    .replace(/^• /gm, '- ')            // convert bullet chars to markdown list items
+    .trim();
+
+  const m = new Marked({ renderer: makeRenderer() });
+  const body = m.parse(cleaned) as string;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${pageTitle}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>${CSS}</style>
+</head>
+<body>
+  <div class="resume">
+${body.trim().split('\n').map(l => `    ${l}`).join('\n')}
+  </div>
+</body>
+</html>`;
+}

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { renderResumeHtml } from '../src/lib/render.js';
+
+const SAMPLE = `
+# Jane Doe
+## Senior Engineer
+
+<jane@example.com>  |  (555) 123-4567
+
+linkedin.com/in/janedoe  |  github.com/janedoe
+
+## Summary
+
+Built things that mattered.
+
+## Experience
+
+### Staff Engineer | Acme Corp
+<!-- tech: Go, Postgres, Kubernetes -->
+2021 – 2024
+
+• Led migration of monolith to microservices.
+• Reduced p99 latency by 40%.
+
+## Education
+
+MIT — B.S., Computer Science
+`.trim();
+
+describe('renderResumeHtml', () => {
+  it('returns a complete HTML document', () => {
+    const html = renderResumeHtml(SAMPLE);
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('</html>');
+  });
+
+  it('renders the name as h1', () => {
+    expect(renderResumeHtml(SAMPLE)).toContain('<h1>Jane Doe</h1>');
+  });
+
+  it('marks the role subtitle as h2.role', () => {
+    expect(renderResumeHtml(SAMPLE)).toContain('<h2 class="role">Senior Engineer</h2>');
+  });
+
+  it('marks section headers as h2.section', () => {
+    const html = renderResumeHtml(SAMPLE);
+    expect(html).toContain('<h2 class="section">Summary</h2>');
+    expect(html).toContain('<h2 class="section">Experience</h2>');
+  });
+
+  it('marks the contact line as p.contact', () => {
+    const html = renderResumeHtml(SAMPLE);
+    expect(html).toContain('class="contact"');
+    expect(html).toContain('jane@example.com');
+  });
+
+  it('marks the links line as p.links', () => {
+    expect(renderResumeHtml(SAMPLE)).toContain('class="links"');
+  });
+
+  it('marks date paragraphs as p.date', () => {
+    expect(renderResumeHtml(SAMPLE)).toContain('<p class="date">2021 – 2024</p>');
+  });
+
+  it('strips HTML comments', () => {
+    const html = renderResumeHtml(SAMPLE);
+    expect(html).not.toContain('tech:');
+    expect(html).not.toContain('<!--');
+  });
+
+  it('converts bullet chars to list items', () => {
+    const html = renderResumeHtml(SAMPLE);
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>');
+    expect(html).not.toContain('•');
+  });
+
+  it('uses the pageTitle in the <title> tag', () => {
+    const html = renderResumeHtml(SAMPLE, 'Resume — Acme Corp');
+    expect(html).toContain('<title>Resume — Acme Corp</title>');
+  });
+
+  it('loads Inter from Google Fonts', () => {
+    expect(renderResumeHtml(SAMPLE)).toContain('fonts.googleapis.com');
+  });
+});


### PR DESCRIPTION
## Summary
This branch improves the tailoring pipeline end to end so generated resumes and cover letters stay grounded in real source material, correctly identify the target company, and can now be rendered as a clean HTML resume output. It also switches the AI integration from OpenAI to Anthropic so the CLI uses the current model provider expected by the project.

From a user perspective, this reduces fabricated or conflated resume content, improves cover letter quality and company matching for job-board postings, and adds a new minimalist HTML rendering path for the tailored resume content.

## Root Cause
The existing tailoring flow had a few compounding issues:
- prompts allowed too much room for extrapolation and stale assumptions
- company extraction could misidentify employers from job-board pages
- cover letter generation could blur technologies, employers, and salutation details
- the project still targeted the previous AI provider integration
- resume output stopped at markdown rather than offering a polished renderable HTML format

## Fix
This PR tightens the prompting and tailoring pipeline in several places:
- fixes Clerk auth and the boards API shape in the Huntr integration
- adds base cover letter support and correct salutation handling
- switches model calls from OpenAI to Anthropic
- tightens resume and cover letter prompts to prevent fact fabrication and experience extrapolation
- extracts the real company name from job descriptions more reliably
- supports per-employer tech metadata in resume HTML comments
- promotes supplemental bullets into the resume flow and adds supporting resume content files
- adds an HTML resume renderer with accompanying tests

## Validation
I validated the branch with:
- `npm test`
- `npm run typecheck`
