### PR TITLE
feat: sharpen resume and cover letter prompts with voice, ownership, and structure rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist/
 *.env.local
 output/*
 !output/.gitkeep
+resume.md
+bio.md
+cover-letter.md
+resume-supplemental.md

--- a/bio.sample.md
+++ b/bio.sample.md
@@ -1,0 +1,5 @@
+I am a senior software engineer who tends to do my best work in ambiguous environments where a team needs someone to bring structure without adding drama. I enjoy taking half-defined product ideas, legacy systems, or messy operational workflows and turning them into software that is easier to understand and easier to trust.
+
+Over the last decade, I have worked across backend services, internal tools, frontend applications, and cloud infrastructure. I am strongest when I can connect technical execution to business outcomes: improving reliability, shortening delivery cycles, reducing manual work, and helping teams make better decisions with clearer systems.
+
+I usually gravitate toward teams that value ownership, clear writing, practical architecture, and collaboration across engineering, product, and design. I am especially energized by roles where I can combine hands-on coding with technical leadership, mentorship, and product judgment.

--- a/cover-letter.sample.md
+++ b/cover-letter.sample.md
@@ -1,0 +1,13 @@
+Dear Hiring Team,
+
+I am excited to apply for the Senior Software Engineer role at [Company]. The combination of product ownership, technical depth, and cross-functional collaboration in this position is a strong match for the work I have enjoyed most throughout my career.
+
+In recent roles, I have built and improved backend services, internal platforms, and customer-facing applications using TypeScript, Node.js, .NET, React, and cloud infrastructure on AWS and Azure. I tend to be most effective where a team needs someone who can move between architecture, implementation, and communication: clarifying requirements, reducing operational friction, and helping good ideas turn into reliable software.
+
+What stands out to me about [Company] is the opportunity to contribute not just as an individual engineer, but as a thoughtful teammate who can improve systems and help others move faster. I care a lot about maintainability, observability, and building software that solves real user problems without unnecessary complexity.
+
+Thank you for your time and consideration. I would welcome the chance to discuss how my background could support your team and the goals of this role.
+
+Sincerely,
+
+Jordan Avery

--- a/resume-supplemental.sample.md
+++ b/resume-supplemental.sample.md
@@ -1,0 +1,35 @@
+# Resume Supplemental Detail
+
+This file is factual reference for AI tailoring. Do not include this content verbatim in output. Use it to preserve accuracy, add missing context, and choose stronger examples when the base resume is too compressed.
+
+---
+
+## Staff Software Engineer | Northwind Labs (2022-2025)
+
+- Owned technical direction for an operations workflow platform spanning approvals, escalations, and audit history.
+- Coordinated work across product, design, and support to prioritize reliability improvements and admin UX cleanup.
+- Introduced queue-based processing for long-running jobs, reducing timeout-related failures during peak usage.
+- Standardized Terraform modules and deployment workflows used by multiple engineering teams.
+
+## Senior Software Engineer | Harbor Health (2018-2022)
+
+- Shipped scheduling, intake, and reporting capabilities for a multi-tenant healthcare platform.
+- Improved partner integrations and data quality, reducing manual reconciliation work for operations teams.
+- Wrote technical documentation and implementation guides to make onboarding easier for new engineers.
+- Frequently acted as the bridge between engineering and non-technical stakeholders during delivery planning.
+
+## Software Engineer | Atlas Commerce (2015-2018)
+
+- Built commerce workflows for order management, promotions, and operational reporting.
+- Improved background job reliability and database performance for high-volume traffic periods.
+- Helped modernize deployment and monitoring practices in a previously ad hoc environment.
+
+## Extended Technical Skills
+
+Programming Languages: TypeScript, JavaScript, C#, SQL, Ruby
+
+Cloud & Infrastructure: AWS, Azure, Terraform, Docker, CI/CD
+
+Frameworks & Platforms: Node.js, React, .NET, Rails, PostgreSQL, MySQL, Redis
+
+Working Style: Technical leadership, mentoring, architecture reviews, documentation, cross-functional collaboration

--- a/resume.sample.md
+++ b/resume.sample.md
@@ -1,0 +1,56 @@
+# Jordan Avery
+
+## Senior Software Engineer
+
+<jordan.avery@example.com> | (555) 123-4567 | Chicago, IL | Open to remote / hybrid
+
+linkedin.com/in/jordanavery | github.com/jordanavery | jordanavery.dev
+
+## Summary
+
+Senior software engineer with 10+ years building backend platforms, internal tooling, and customer-facing web applications. Strong background in TypeScript, Node.js, cloud infrastructure, API design, and cross-functional delivery. Known for clarifying messy systems, improving reliability, and shipping pragmatic product improvements with small teams.
+
+## Selected Impact
+
+- Reduced deployment time from 45 minutes to under 10 minutes by standardizing CI/CD workflows across 6 services.
+- Led migration from a monolith to event-driven services, improving release safety and isolating customer-facing incidents.
+- Built analytics and operational dashboards that helped support teams resolve incidents 30% faster.
+
+## Professional Experience
+
+### Staff Software Engineer | Northwind Labs
+<!-- tech: TypeScript, Node.js, PostgreSQL, AWS (Lambda, ECS, RDS, SQS), Terraform -->
+2022-2025 | Remote
+
+- Led architecture for a workflow platform used by operations and customer success teams across 3 business units.
+- Introduced service ownership conventions, alert runbooks, and deployment checklists that improved reliability and on-call clarity.
+- Partnered with design and product to turn a brittle admin surface into a faster, task-oriented internal tool.
+
+### Senior Software Engineer | Harbor Health
+<!-- tech: C#, .NET, React, Azure (App Service, Functions, Service Bus, SQL), GitHub Actions -->
+2018-2022 | Boston, MA
+
+- Delivered scheduling and patient-intake features for a multi-tenant healthcare application serving clinics in 12 states.
+- Built integrations between internal systems and third-party vendors, improving data accuracy and reducing manual reconciliation work.
+- Mentored early-career engineers and helped establish lightweight engineering standards for pull requests, observability, and testing.
+
+### Software Engineer | Atlas Commerce
+<!-- tech: Ruby, Rails, JavaScript, MySQL, Redis, Docker -->
+2015-2018 | Chicago, IL
+
+- Built e-commerce features spanning order management, promotions, and reporting for mid-market retail customers.
+- Improved background job reliability and query performance for high-traffic seasonal events.
+
+## Education
+
+Example State University - B.S., Computer Science
+
+## Technical Skills
+
+### Core Technologies
+
+TypeScript, Node.js, React, C#, .NET, PostgreSQL, MySQL, AWS, Azure, Terraform, Docker, GitHub Actions
+
+### Keywords
+
+Backend Engineering, Platform Engineering, Internal Tools, API Design, Cloud Infrastructure, Observability, Developer Experience, Cross-Functional Delivery


### PR DESCRIPTION
## Summary

- **Resume prompt**: Add structured ACCURACY / TAILORING / VOICE / LENGTH sections. Key additions: ownership verb mandate (built/shipped/led — never helped/assisted/worked on), metric-per-bullet requirement, headline adaptation to target role level, JD-driven Selected Impact curation, bio `<!-- tech: ... -->` awareness so personal project tech can surface correctly attributed.
- **Cover letter prompt**: Escalate tone from "slightly dangerous" → "dangerous". Require a fresh, opinionated p1 opener per role (no reusing base template lines). Ban supplicant phrases ("excited to apply", "passionate about", "look forward to hearing from you"). Require a confident closing. Add outcome-grounded tech references in p2. Unlock bio AI/personal project surfacing for ML/infra/full-stack SaaS roles.
- **Tests**: Update two assertions to match revised prompt strings.

## Test plan

- [x] `npm test` — 21/21 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added starter templates for resume, bio, cover letter, and resume supplemental document.
  * Enhanced support for optional base cover letter and resume supplemental files.

* **Documentation**
  * Updated README with template instructions and setup guidance.

* **Improvements**
  * Strengthened prompt accuracy with stricter anti-fabrication rules and improved technology attribution requirements.

* **Chores**
  * Updated AI provider with new API key configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
