### PR TITLE
feat: spinner, improved retry, and contact link fixes

### DIFF
--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -314,6 +314,9 @@ export function renderCoverLetterHtml(markdown: string, pageTitle?: string): str
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${safeTitle}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     ${CSS}
     .cover-letter {

--- a/src/lib/tailor.ts
+++ b/src/lib/tailor.ts
@@ -8,8 +8,8 @@ import {
 import { TailorInput, TailorOutput } from '../types/index.js';
 
 /**
- * Generate a tailored resume AND cover letter in parallel.
- * Returns both strings once both API calls complete.
+ * Generate a tailored resume then cover letter (serially).
+ * Serial execution avoids simultaneous 429s fighting over the retry spinner.
  */
 export async function tailorDocuments(
   model: string,
@@ -17,11 +17,8 @@ export async function tailorDocuments(
   verbose = false,
   complete = defaultComplete,
 ): Promise<TailorOutput> {
-  const [resume, coverLetter] = await Promise.all([
-    complete(model, resumeSystemPrompt(), resumeUserPrompt(input), verbose),
-    complete(model, coverLetterSystemPrompt(), coverLetterUserPrompt(input), verbose),
-  ]);
-
+  const resume = await complete(model, resumeSystemPrompt(), resumeUserPrompt(input), verbose);
+  const coverLetter = await complete(model, coverLetterSystemPrompt(), coverLetterUserPrompt(input), verbose);
   return { resume, coverLetter };
 }
 


### PR DESCRIPTION
## Summary

- **`spinner.ts`**: animated progress bar for work and retry waits (with live countdown timer)
- **`ai.ts`**: upgrade retry to honor `Retry-After` header, also catch 529, add ±20% jitter, show live spinner during backoff
- **`tailor.ts` + `huntr.ts`**: wrap `tailorDocuments` in `withSpinner`; drop `datePrefix` from tailor slugs
- **`render.ts`**: tighten `isUrlLike()` to require scheme/www/path so `Node.js`-style tokens aren't linkified; fix `normalizeContactLinks()` to use `h2Count` so contact/links paragraphs (after the role heading) are still processed
- **`ai.ts`**: fail-fast when model is `auto`/`default` and `AZURE_OPENAI_DEPLOYMENT` is unset

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm test` — ai, render, files suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Added optimized font loading to cover letters, matching resume rendering behavior.
  * Improved document generation execution process for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->