### PR TITLE
feat: auto-compact resume PDF when content overflows one page

### DIFF
--- a/src/commands/huntr.ts
+++ b/src/commands/huntr.ts
@@ -6,7 +6,7 @@ import { tailorDocuments } from '../lib/tailor.js';
 import { describeProvider } from '../lib/ai.js';
 import { withSpinner } from '../lib/spinner.js';
 import { findFile, readFile, JOB_SHIT_DIR } from '../lib/files.js';
-import { renderResumeHtml, renderCoverLetterHtml, renderPdf } from '../lib/render.js';
+import { renderResumeHtml, renderCoverLetterHtml, renderPdf, renderResumePdfFit } from '../lib/render.js';
 
 // ---------------------------------------------------------------------------
 // Huntr API types (inlined — huntr-cli has no library exports)
@@ -606,8 +606,8 @@ async function tailorAndWrite(args: {
   if (pdf) {
     const resumePdfOut = join(outputDir, `resume-${slug}.pdf`);
     try {
-      await renderPdf(resumeHtmlOut, resumePdfOut);
-      console.log(`    ✓ resume (pdf) → ${resumePdfOut}`);
+      const fit = await renderResumePdfFit(output.resume, `Resume - ${companyName}`, resumeHtmlOut, resumePdfOut);
+      console.log(`    ✓ resume (pdf) → ${resumePdfOut}${fit ? '' : ' (compact: still >1 page)'}`);
     } catch (err) {
       console.warn(`    ⚠ PDF generation skipped: ${(err as Error).message}`);
     }

--- a/src/commands/tailor.ts
+++ b/src/commands/tailor.ts
@@ -6,7 +6,7 @@ import { tailorDocuments } from '../lib/tailor.js';
 import { describeProvider } from '../lib/ai.js';
 import { withSpinner } from '../lib/spinner.js';
 import { findFile, readFile, JOB_SHIT_DIR } from '../lib/files.js';
-import { renderResumeHtml, renderCoverLetterHtml, renderPdf } from '../lib/render.js';
+import { renderResumeHtml, renderCoverLetterHtml, renderPdf, renderResumePdfFit } from '../lib/render.js';
 
 function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
@@ -131,9 +131,8 @@ export function registerTailorCommand(program: Command): void {
       writeFileSync(coverLetterOut, output.coverLetter, 'utf8');
 
       const resumeHtmlOut = join(opts.output, `resume-${slug}.html`);
-      writeFileSync(resumeHtmlOut, renderResumeHtml(output.resume, `Resume - ${opts.company}`), 'utf8');
-
       const coverLetterHtmlOut = join(opts.output, `cover-letter-${slug}.html`);
+      writeFileSync(resumeHtmlOut, renderResumeHtml(output.resume, `Resume - ${opts.company}`), 'utf8');
       writeFileSync(coverLetterHtmlOut, renderCoverLetterHtml(output.coverLetter, `Cover Letter - ${opts.company}`), 'utf8');
 
       console.log(`✓ resume       → ${resumeOut}`);
@@ -144,8 +143,8 @@ export function registerTailorCommand(program: Command): void {
       if (opts.pdf) {
         const resumePdfOut = join(opts.output, `resume-${slug}.pdf`);
         try {
-          await renderPdf(resumeHtmlOut, resumePdfOut);
-          console.log(`✓ resume (pdf) → ${resumePdfOut}`);
+          const fit = await renderResumePdfFit(output.resume, `Resume - ${opts.company}`, resumeHtmlOut, resumePdfOut);
+          console.log(`✓ resume (pdf) → ${resumePdfOut}${fit ? '' : ' (compact: still >1 page)'}`);
         } catch (err) {
           console.warn(`⚠ PDF generation skipped: ${(err as Error).message}`);
           console.warn('  Run `npm run setup` to check Chrome prerequisites.');

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'child_process';
 import { resolve } from 'path';
 import { pathToFileURL } from 'url';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { Marked } from 'marked';
 import sanitizeHtmlLib from 'sanitize-html';
 
@@ -263,7 +263,51 @@ function extractH1(markdown: string): string | undefined {
 /**
  * Convert a tailored resume (markdown) to a styled, print-ready HTML string.
  */
-export function renderResumeHtml(markdown: string, pageTitle?: string): string {
+// Compact CSS overrides — injected when content is slightly over one page.
+// Tightens spacing without touching font sizes to keep readability.
+const COMPACT_CSS = `
+  @page { margin: 0.65cm !important; }
+  li, p { line-height: 1.4 !important; margin-bottom: 2px !important; }
+  h2.section { margin-top: 10px !important; margin-bottom: 3px !important; }
+  h3 { margin-top: 7px !important; margin-bottom: 1px !important; }
+  p.links { margin-bottom: 10px !important; }
+  ul { margin: 0 0 1px 0 !important; }
+`;
+
+/**
+ * Read the page count of a PDF file.
+ * Works with Chrome headless --print-to-pdf output.
+ */
+export function getPdfPageCount(pdfPath: string): number {
+  const content = readFileSync(pdfPath, 'latin1');
+  const match = content.match(/\/Type\s*\/Pages[\s\S]*?\/Count\s+(\d+)/);
+  return match ? parseInt(match[1], 10) : 1;
+}
+
+/**
+ * Generate a resume PDF, retrying with compact spacing if content overflows one page.
+ * Overwrites htmlPath with the compact HTML when compaction is applied.
+ * Returns true if the final PDF fits on one page.
+ */
+export async function renderResumePdfFit(
+  markdown: string,
+  title: string,
+  htmlPath: string,
+  pdfPath: string,
+): Promise<boolean> {
+  writeFileSync(htmlPath, renderResumeHtml(markdown, title), 'utf8');
+  await renderPdf(htmlPath, pdfPath);
+
+  const pages = getPdfPageCount(pdfPath);
+  if (pages <= 1) return true;
+
+  // Slightly over — retry with compact CSS
+  writeFileSync(htmlPath, renderResumeHtml(markdown, title, true), 'utf8');
+  await renderPdf(htmlPath, pdfPath);
+  return getPdfPageCount(pdfPath) <= 1;
+}
+
+export function renderResumeHtml(markdown: string, pageTitle?: string, compact = false): string {
   const resolvedTitle = pageTitle ?? (extractH1(markdown) ? `${extractH1(markdown)} – Resume` : 'Resume');
   const cleaned = markdown
     .replace(/<!--[\s\S]*?-->/g, '')
@@ -289,7 +333,7 @@ export function renderResumeHtml(markdown: string, pageTitle?: string): string {
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <style>${CSS}</style>
+  <style>${CSS}${compact ? COMPACT_CSS : ''}</style>
 </head>
 <body>
   <div class="resume">


### PR DESCRIPTION
## Summary
- Adds `renderResumePdfFit()` in `render.ts` that generates a PDF, checks the page count, and retries with compact CSS if content overflows one page
- `getPdfPageCount()` parses Chrome headless PDF output via raw byte scan (no new dependencies)
- `COMPACT_CSS` tightens `@page` margins, `line-height`, and section spacing without touching font sizes
- Both `tailor` and `huntr` commands now use `renderResumePdfFit` for resume PDFs; cover letters unchanged

## Test plan
- [ ] `npm test` passes (52/52)
- [ ] `npm run typecheck` clean
- [ ] Run `huntr tailor-all --pdf` and verify resumes that were previously 2 pages are now compacted to 1
- [ ] Verify `(compact: still >1 page)` warning appears for genuinely long resumes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume PDFs now automatically apply compact formatting to fit content on a single page when needed.
  * Enhanced console output provides clearer feedback on resume PDF generation results, indicating whether the output is fully fitted or requires compact styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->