### PR TITLE
fix: correct bad conflict resolutions in ai.ts and render.ts

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -122,27 +122,27 @@ export function describeProvider(model: string): string {
  *   4. ANTHROPIC_API_KEY                            → Anthropic Claude (claude-haiku-4-5)
  */
 export async function complete(
-  clientOrModel: Anthropic | OpenAI | AzureOpenAI | string,
-  modelOrSystemPrompt: string,
-  systemPromptOrUserPrompt: string,
-  userPromptOrVerbose?: string | boolean,
+  model: string,
+  systemPrompt: string,
+  userPrompt: string,
   verboseArg?: boolean,
 ): Promise<string> {
-  // Support both legacy signature:
-  //   complete(client, model, systemPrompt, userPrompt, verbose?)
-  // and new signature:
-  //   complete(model, systemPrompt, userPrompt, verbose?)
-  const usingInjectedClient = typeof clientOrModel !== 'string';
+  // Signature: complete(model, systemPrompt, userPrompt, verbose?)
+  const verbose = verboseArg ?? false;
 
-  const model = usingInjectedClient
+  // Existing implementation below should continue to use `model`,
+  // `systemPrompt`, `userPrompt`, and `verbose` as before.
+  const userPromptOrVerbose = userPrompt;
+  const systemPromptOrUserPrompt = systemPrompt;
+  const modelOrSystemPrompt = model;
+  const clientOrModel = model;
+  const usingInjectedClient = false;
+
+  const resolvedModel = usingInjectedClient
     ? modelOrSystemPrompt
     : (clientOrModel as string);
 
-  const systemPrompt = usingInjectedClient
-    ? systemPromptOrUserPrompt
-    : modelOrSystemPrompt;
-
-  const userPrompt = usingInjectedClient
+  const resolvedSystemPrompt = usingInjectedClient
     ? (typeof userPromptOrVerbose === 'string' ? userPromptOrVerbose : '')
     : systemPromptOrUserPrompt;
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -2,6 +2,23 @@ import OpenAI, { AzureOpenAI } from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
 import { startRetrySpinner } from './spinner.js';
 
+export function createAnthropicClient(
+  options?: ConstructorParameters<typeof Anthropic>[0],
+): Anthropic {
+  if (options) {
+    return new Anthropic(options);
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY ?? process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'Missing ANTHROPIC_API_KEY (or OPENAI_API_KEY) environment variable for Anthropic client',
+    );
+  }
+
+  return new Anthropic({ apiKey });
+}
+
 /**
  * Resolve an abstract model alias to a provider-specific model ID.
  * If the hint already looks like a real model ID, pass it through.

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -105,11 +105,33 @@ export function describeProvider(model: string): string {
  *   4. ANTHROPIC_API_KEY                            → Anthropic Claude (claude-haiku-4-5)
  */
 export async function complete(
-  model: string,
-  systemPrompt: string,
-  userPrompt: string,
-  verbose = false,
+  clientOrModel: Anthropic | OpenAI | AzureOpenAI | string,
+  modelOrSystemPrompt: string,
+  systemPromptOrUserPrompt: string,
+  userPromptOrVerbose?: string | boolean,
+  verboseArg?: boolean,
 ): Promise<string> {
+  // Support both legacy signature:
+  //   complete(client, model, systemPrompt, userPrompt, verbose?)
+  // and new signature:
+  //   complete(model, systemPrompt, userPrompt, verbose?)
+  const usingInjectedClient = typeof clientOrModel !== 'string';
+
+  const model = usingInjectedClient
+    ? modelOrSystemPrompt
+    : (clientOrModel as string);
+
+  const systemPrompt = usingInjectedClient
+    ? systemPromptOrUserPrompt
+    : modelOrSystemPrompt;
+
+  const userPrompt = usingInjectedClient
+    ? (typeof userPromptOrVerbose === 'string' ? userPromptOrVerbose : '')
+    : systemPromptOrUserPrompt;
+
+  const verbose = usingInjectedClient
+    ? (typeof verboseArg === 'boolean' ? verboseArg : false)
+    : (typeof userPromptOrVerbose === 'boolean' ? userPromptOrVerbose : false);
 
   // ── 1. Gemini ───────────────────────────────────────────────────────────
   if (process.env.GEMINI_API_KEY) {

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -65,7 +65,8 @@ function normalizeContactLinks(markdown: string): string {
     // The first ## is the role subtitle; contact/links follow it.
     // Only treat content as body (and skip linkification) once we hit
     // the second ## (the first real section heading).
-    if (trimmed.startsWith('##')) {
+    // Use /^## / so that ### headings don't increment h2Count.
+    if (/^## /.test(trimmed)) {
       h2Count++;
     }
 

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -107,3 +107,62 @@ describe('renderResumeHtml', () => {
     expect(html).toContain('<title>Resume</title>');
   });
 });
+
+describe('normalizeContactLinks / isUrlLike', () => {
+  // Build a minimal resume with a controlled contact line so we can test
+  // linkification without the rest of the rendering noise.
+  function contactHtml(contactLine: string): string {
+    return renderResumeHtml(
+      `# Test Person\n## Engineer\n\n${contactLine}\n\n## Summary\n\nSome text.`,
+    );
+  }
+
+  it('linkifies bare https:// URLs in the contact area', () => {
+    const html = contactHtml('https://example.com/foo');
+    expect(html).toContain('<a href="https://example.com/foo">https://example.com/foo</a>');
+  });
+
+  it('linkifies www. URLs in the contact area', () => {
+    // Must include a pipe so normalizeContactLinks processes the line
+    const html = contactHtml('www.example.com/in/janedoe | (555) 123-4567');
+    expect(html).toContain('<a href="https://www.example.com/in/janedoe">www.example.com/in/janedoe</a>');
+  });
+
+  it('linkifies bare domain/path URLs in the contact area', () => {
+    const html = contactHtml('linkedin.com/in/janedoe | github.com/janedoe');
+    expect(html).toContain('<a href="https://linkedin.com/in/janedoe">linkedin.com/in/janedoe</a>');
+  });
+
+  it('does NOT linkify bare dotted identifiers like Node.js', () => {
+    const html = contactHtml('Node.js | react');
+    expect(html).not.toContain('<a href');
+  });
+
+  it('does NOT linkify pipe-separated content after the second ## heading', () => {
+    // The "Skills" section has pipes but should not be linkified.
+    const html = renderResumeHtml(
+      `# Dev\n## Engineer\n\ngithub.com/dev | more\n\n## Summary\n\nText.\n\n## Skills\n\nNode.js | React | Go`,
+    );
+    // Inside the Skills section, pipes should be literal — not linkified
+    expect(html).not.toMatch(/Skills[\s\S]*?<a href/);
+  });
+
+  it('does NOT count ### headings toward the h2 stop-linkify threshold', () => {
+    // If ### incorrectly incremented h2Count, linkification would stop
+    // too early and the contact link below would not be wrapped in <a>.
+    const md = [
+      '# Dev',
+      '## Engineer',
+      '',
+      '### note',                       // h3 — must NOT increment h2Count
+      '',
+      'github.com/dev | (555) 123-4567', // should still be linkified (h2Count still 1)
+      '',
+      '## Summary',
+      '',
+      'Text.',
+    ].join('\n');
+    const html = renderResumeHtml(md);
+    expect(html).toContain('<a href="https://github.com/dev">github.com/dev</a>');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes 6 incorrect conflict resolutions that were left in the branch after merging.

**`src/lib/ai.ts`**
- `resolveModel`: only `'auto'`/`'default'` are treated as abstract aliases — real model IDs (including fragments like `'haiku'`, `'sonnet'`, etc.) now pass through unchanged
- `withRetry`: replaced 30 s flat delay + console.log with exponential backoff (±20% jitter, capped at 60 s), honors `Retry-After` response header, handles HTTP 529 alongside 429, shows a live countdown spinner while waiting
- Added missing `import { startRetrySpinner }` from `spinner.ts`

**`src/lib/render.ts`**
- `isUrlLike`: requires an explicit scheme, `www.`, or path component — prevents bare dotted identifiers like `Node.js` from being linkified
- `normalizeContactLinks`: added `h2Count` guard so pipe-separated content in body sections isn't linkified
- `makeRenderer`: restored `inJobSection` / `closeJobSection` state and `<div class="job-section">` wrapping needed for `break-inside: avoid` in print/PDF
- `sanitizeHtml`: added `div` to allowed tags, `class` attribute, and `job-section` to allowed classes (was silently stripping the renderer's output)
- `renderResumeHtml`: derives title dynamically from H1 instead of hardcoding; calls `closeJobSection()` after parse; restored Google Fonts `<link>` tags
- `renderCoverLetterHtml`: uses `resolvedTitle` (not raw `pageTitle`) in `escapeHtml()`
- `renderPdf`: replaced `execSync` shell string with `execFileSync` args array + `pathToFileURL` (eliminates shell injection risk)

**`src/lib/spinner.ts`**
- Added missing file (this branch predates when spinner.ts was introduced)

## Test plan
- [ ] `npm run typecheck` — passes
- [ ] `npm test` — all 33 tests pass across 4 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heading-level detection so section bodies and link generation behave correctly.
  * Refined contact-area URL recognition to convert real website links while leaving technical identifiers unchanged.

* **Tests**
  * Added tests validating contact linkification, heading behavior, and scope-limited link processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->