### PR TITLE
Make tailor test hermetic

### DIFF
--- a/tests/tailor.test.ts
+++ b/tests/tailor.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { tailorDocuments, tailorResume } from '../src/lib/tailor.js';
+import * as files from '../src/lib/files.js';
 import { TailorInput } from '../src/types/index.js';
 
 const sampleInput: TailorInput = {
@@ -16,11 +17,35 @@ describe('tailorDocuments', () => {
       .mockImplementationOnce(async () => '# Tailored Resume')
       .mockImplementationOnce(async () => 'Dear Hiring Manager,');
 
-    const result = await tailorDocuments('haiku', sampleInput, false, mockComplete);
+    const loadPromptSpy = vi.spyOn(files, 'loadPrompt').mockImplementation((filename, defaultValue) => {
+      if (filename === 'resume-system.md') return 'resume system prompt';
+      if (filename === 'cover-letter-system.md') return 'cover letter system prompt';
+      return defaultValue;
+    });
 
-    expect(mockComplete).toHaveBeenCalledTimes(2);
-    expect(result.resume).toBe('# Tailored Resume');
-    expect(result.coverLetter).toBe('Dear Hiring Manager,');
+    try {
+      const result = await tailorDocuments('auto', sampleInput, false, mockComplete);
+
+      expect(mockComplete).toHaveBeenCalledTimes(2);
+      expect(mockComplete).toHaveBeenNthCalledWith(
+        1,
+        'auto',
+        'resume system prompt',
+        expect.stringContaining('Now produce the tailored resume.'),
+        false,
+      );
+      expect(mockComplete).toHaveBeenNthCalledWith(
+        2,
+        'auto',
+        'cover letter system prompt',
+        expect.stringContaining('Now produce the cover letter.'),
+        false,
+      );
+      expect(result.resume).toBe('# Tailored Resume');
+      expect(result.coverLetter).toBe('Dear Hiring Manager,');
+    } finally {
+      loadPromptSpy.mockRestore();
+    }
   });
 
   it('propagates errors from either parallel call', async () => {


### PR DESCRIPTION
## Summary
- stub `loadPrompt` in the `tailorDocuments` test so local or home-directory prompt overrides cannot affect it
- assert the mocked `complete` calls receive deterministic resume and cover-letter system prompts
- keep the spy scoped to the test and restore it after execution

## Verification
- npx vitest run tests/tailor.test.ts
- npm run typecheck