### PR TITLE
[codex] fix compilation, improve prompts, add smoke tests & AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev -- <command>   # run without building (uses tsx)
+npm run build              # compile to dist/
+npm test                   # run tests (vitest)
+npm run typecheck          # tsc --noEmit
+npm run lint               # eslint
+```
+
+Run a single test file: `npx vitest run tests/files.test.ts`
+
+## Architecture
+
+Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level commands:
+
+- **`tailor`** — one-off tailoring from a local JD file: `job-shit tailor --company "Acme" --job jd.txt`
+- **`huntr`** — Huntr.co integration subcommands (see below)
+
+### Core lib (`src/lib/`)
+
+- `ai.ts` — thin Anthropic/Codex wrapper (`complete()`, takes an injected client)
+- `tailor.ts` — `tailorDocuments()` fans out resume + cover letter calls via `Promise.all`
+- `prompts.ts` — system/user prompts for resume and cover letter, kept separate
+- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.job-shit/`
+
+### Commands (`src/commands/`)
+
+- `tailor.ts` — CLI flags → `tailorDocuments()` → writes `output/resume-<slug>.md` + `output/cover-letter-<slug>.md`
+- `huntr.ts` — all Huntr subcommands; inlined HTTP client (huntr-cli has no library exports)
+  - `huntr wishlist` — list jobs in the Wishlist stage
+  - `huntr jobs` — list all jobs with their current stage
+  - `huntr tailor <jobId>` — tailor one job (board auto-detected)
+  - `huntr tailor-all` — tailor every wishlist job in one shot
+
+### Config
+
+`src/config.ts` — loads `ANTHROPIC_API_KEY` / `ANTHROPIC_MODEL` (falls back to `OPENAI_API_KEY` / `OPENAI_MODEL`, defaults to `Codex-sonnet-4-5`). `resolveHuntrToken()` checks env → `~/.huntr/config.json` → system keychain (keytar), matching huntr-cli's credential chain.
+
+### Output
+
+All generated files go under `output/` (gitignored). Naming: `resume-<company>-<title>-<jobId>.md` / `cover-letter-<company>-<title>-<jobId>.md`.
+
+## Conventions
+
+- TypeScript ESM (`"type": "module"`). Use `.js` extensions in imports.
+- Tests in `tests/` with Vitest. Anthropic client is injected so tests never hit the network.
+- Run `npm run typecheck` and `npm test` before committing.


### PR DESCRIPTION
## Summary

This PR bundles four related improvements that were committed on `main` but hadn't been pushed to a review branch.

## Changes

### 1. Build script fix (`package.json`)
The `build` script only ran `tsc`, leaving the `src/templates/` directory out of `dist/`. Any runtime call that reads templates from `dist/templates/` would fail after a clean build. Fixed by appending `cp -r src/templates dist/templates` so the compiled output is self-contained.

### 2. Dead code cleanup (`src/lib/ai.ts`)
A previous bad conflict resolution left a block of shadowed, unreachable variable declarations inside `complete()` (e.g. `usingInjectedClient`, `resolvedModel`, duplicate `verbose`). These caused a TypeScript duplicate-binding error and confused the logic. Removed the dead block; the real implementation below it is unaffected.

### 3. Improved default system prompts (`src/lib/prompts.ts`)
Both resume and cover letter system prompts were placeholder stubs that told the user to "provide a prompt override." Replaced them with full, production-quality prompts covering:
- **Accuracy guardrails** — explicit instruction to never fabricate credentials or metrics
- **ATS/tailoring rules** — keyword mirroring, action-verb leads, quantified impact
- **Format/voice rules** — markdown-only output, no preamble, authentic candidate voice

### 4. End-to-end smoke tests (`tests/smoke.test.ts`)
Added a new 7-test smoke suite that wires the full pipeline (prompts → `tailorDocuments` → `renderResumeHtml` / `renderCoverLetterHtml`) with a mocked `complete()` so it never hits the network. Tests verify:
- Both documents are produced
- System prompts contain required accuracy guardrails
- User prompts carry all input fields (company, title, JD, resume)
- HTML output is valid and free of raw markdown
- Supplemental resume content and base cover letter passthrough work correctly

### 5. `AGENTS.md`
Added a top-level `AGENTS.md` so Codex and other AI agents working in this repo get consistent guidance on commands, architecture, and conventions without having to infer them from source.

## Validation

All 65 tests pass (`npm test`) and `npm run typecheck` is clean.
