### PR TITLE
[codex] Align copy-assets imports

### DIFF
--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -3,8 +3,8 @@
  * Cross-platform asset copy for the build step.
  * Replaces POSIX `rm -rf ... && cp -r ...` so the build works on Windows too.
  */
-import { cpSync, rmSync } from 'fs';
-import { resolve } from 'path';
+import { cpSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dirname, '..');
 


### PR DESCRIPTION
## Summary

This change finishes the low-risk cleanup on the cross-platform build asset copy step by aligning `scripts/copy-assets.mjs` with the import style used by the other scripts in this repository.

From a user perspective, there is no behavior change in the build itself. The build still compiles TypeScript and then silently copies the template and workbench assets into `dist/`, including the extra `docs/resume-editor.html` file. The value here is consistency and maintainability: the script now matches the rest of the `scripts/` directory by using the explicit `node:` import prefixes for built-in modules.

## Root Cause

Issue #68 was opened to replace Unix-only shell copy commands with a cross-platform Node-based build step. That functional fix is already present, but `scripts/copy-assets.mjs` still used bare `'fs'` and `'path'` imports while sibling scripts used `'node:fs'` and `'node:path'`.

That mismatch was not breaking anything, but it left the file slightly out of step with the repository's current script conventions.

## Fix

The script now imports from:

- `node:fs`
- `node:path`

No copy logic, cleanup behavior, or path resolution behavior changed. The script still relies on Node built-ins only, still uses `import.meta.dirname`, and still resolves paths in an OS-portable way.

## Validation

I verified the build setup and then ran:

```bash
npm run build
```

The build completed successfully with the updated script.

Refs #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script to use modern Node.js module standards for improved compatibility with future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->