### PR TITLE
Rename project to Well-Tailored and add brand guidelines

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -8,7 +8,7 @@ Generated: 2026-03-13 11:30 EDT
 
 ## 1. Project Overview
 
-**Goal:** Modernize the existing `job-shit` CLI into an Azure-hosted workbench that can:
+**Goal:** Modernize the existing `well-tailored` CLI into an Azure-hosted workbench that can:
 
 - tailor resumes and cover letters from either Huntr jobs or pasted ad-hoc job descriptions
 - let the user edit prompts, source documents, and visual theme in one place
@@ -55,7 +55,7 @@ Generated: 2026-03-13 11:30 EDT
 
 | Component | Type | Technology | Path |
 |-----------|------|------------|------|
-| `job-shit` CLI | API/Worker precursor | Node.js, TypeScript, Commander | `src/cli.ts` |
+| `well-tailored` CLI | API/Worker precursor | Node.js, TypeScript, Commander | `src/cli.ts` |
 | Tailoring core | Shared library | TypeScript modules | `src/lib/` |
 | Huntr integration | Service candidate | TypeScript + fetch | `src/commands/huntr.ts` |
 | Rendering pipeline | Shared library | marked, sanitize-html, Chrome headless | `src/lib/render.ts` |

--- a/.env.example
+++ b/.env.example
@@ -10,18 +10,18 @@
 # AZURE_OPENAI_API_KEY=your-azure-api-key-here
 # AZURE_OPENAI_DEPLOYMENT=gpt-4o-mini   # optional, defaults to gpt-4o-mini
 # AZURE_OPENAI_API_VERSION=2024-12-01-preview  # optional
-# JOB_SHIT_AZURE_MODELS=gpt-5-mini,gpt-4.1-mini,my-custom-deployment
+# TAILORED_AZURE_MODELS=gpt-5-mini,gpt-4.1-mini,my-custom-deployment
 # Use deployment names here, not model catalog names.
 
 # ── Option 3: OpenAI (or any OpenAI-compatible endpoint, like Grok) ──────────
 # OPENAI_API_KEY=your-openai-api-key-here
 # OPENAI_BASE_URL=https://api.openai.com/v1   # optional override
 # OPENAI_PROVIDER_NAME=OpenAI                  # optional label, e.g. "Grok"
-# JOB_SHIT_OPENAI_MODELS=gpt-5-mini,gpt-4.1-mini,grok-3-mini
+# TAILORED_OPENAI_MODELS=gpt-5-mini,gpt-4.1-mini,grok-3-mini
 
 # ── Option 4: Anthropic Claude ───────────────────────────────────────────────
 # ANTHROPIC_API_KEY=your-anthropic-api-key-here
-# JOB_SHIT_ANTHROPIC_MODELS=claude-haiku-4-5-20251001,claude-sonnet-4-5
+# TAILORED_ANTHROPIC_MODELS=claude-haiku-4-5-20251001,claude-sonnet-4-5
 
 # Model override (optional — defaults to the provider's recommended model)
 # ANTHROPIC_MODEL=claude-sonnet-4-5
@@ -29,45 +29,45 @@
 # GEMINI_MODEL=gemini-2.0-flash-lite
 
 # Optional workbench defaults
-# JOB_SHIT_PROVIDER=azure
-# JOB_SHIT_TAILORING_PROVIDER=azure
-# JOB_SHIT_SCORING_PROVIDER=openai
-# JOB_SHIT_MODEL=auto
-# JOB_SHIT_TAILORING_MODEL=auto
-# JOB_SHIT_SCORING_MODEL=auto
-# JOB_SHIT_MODELS=auto
-# JOB_SHIT_TAILORING_MODELS=auto
-# JOB_SHIT_SCORING_MODELS=auto
+# TAILORED_PROVIDER=azure
+# TAILORED_TAILORING_PROVIDER=azure
+# TAILORED_SCORING_PROVIDER=openai
+# TAILORED_MODEL=auto
+# TAILORED_TAILORING_MODEL=auto
+# TAILORED_SCORING_MODEL=auto
+# TAILORED_MODELS=auto
+# TAILORED_TAILORING_MODELS=auto
+# TAILORED_SCORING_MODELS=auto
 
 # Named provider profiles (optional, recommended if you want multiple
 # OpenAI-compatible providers side by side, such as OpenAI + Groq).
-# JOB_SHIT_PROVIDER_PROFILES=openai,groq,anthropic,azure
+# TAILORED_PROVIDER_PROFILES=openai,groq,anthropic,azure
 #
-# JOB_SHIT_PROVIDER_OPENAI_KIND=openai
-# JOB_SHIT_PROVIDER_OPENAI_LABEL=OpenAI
-# JOB_SHIT_PROVIDER_OPENAI_API_KEY=your-openai-api-key
-# JOB_SHIT_PROVIDER_OPENAI_DEFAULT_MODEL=gpt-5-mini
-# JOB_SHIT_PROVIDER_OPENAI_MODELS=gpt-5-mini,gpt-4.1-mini
+# TAILORED_PROVIDER_OPENAI_KIND=openai
+# TAILORED_PROVIDER_OPENAI_LABEL=OpenAI
+# TAILORED_PROVIDER_OPENAI_API_KEY=your-openai-api-key
+# TAILORED_PROVIDER_OPENAI_DEFAULT_MODEL=gpt-5-mini
+# TAILORED_PROVIDER_OPENAI_MODELS=gpt-5-mini,gpt-4.1-mini
 #
-# JOB_SHIT_PROVIDER_GROQ_KIND=openai
-# JOB_SHIT_PROVIDER_GROQ_LABEL=Groq
-# JOB_SHIT_PROVIDER_GROQ_API_KEY=your-groq-api-key
-# JOB_SHIT_PROVIDER_GROQ_BASE_URL=https://api.groq.com/openai/v1
-# JOB_SHIT_PROVIDER_GROQ_DEFAULT_MODEL=llama-3.3-70b-versatile
-# JOB_SHIT_PROVIDER_GROQ_MODELS=llama-3.3-70b-versatile,llama-3.1-8b-instant
+# TAILORED_PROVIDER_GROQ_KIND=openai
+# TAILORED_PROVIDER_GROQ_LABEL=Groq
+# TAILORED_PROVIDER_GROQ_API_KEY=your-groq-api-key
+# TAILORED_PROVIDER_GROQ_BASE_URL=https://api.groq.com/openai/v1
+# TAILORED_PROVIDER_GROQ_DEFAULT_MODEL=llama-3.3-70b-versatile
+# TAILORED_PROVIDER_GROQ_MODELS=llama-3.3-70b-versatile,llama-3.1-8b-instant
 #
-# JOB_SHIT_PROVIDER_ANTHROPIC_KIND=anthropic
-# JOB_SHIT_PROVIDER_ANTHROPIC_LABEL=Anthropic
-# JOB_SHIT_PROVIDER_ANTHROPIC_API_KEY=your-anthropic-api-key
-# JOB_SHIT_PROVIDER_ANTHROPIC_DEFAULT_MODEL=claude-sonnet-4-5
+# TAILORED_PROVIDER_ANTHROPIC_KIND=anthropic
+# TAILORED_PROVIDER_ANTHROPIC_LABEL=Anthropic
+# TAILORED_PROVIDER_ANTHROPIC_API_KEY=your-anthropic-api-key
+# TAILORED_PROVIDER_ANTHROPIC_DEFAULT_MODEL=claude-sonnet-4-5
 #
-# JOB_SHIT_PROVIDER_AZURE_KIND=azure
-# JOB_SHIT_PROVIDER_AZURE_LABEL=Azure OpenAI
-# JOB_SHIT_PROVIDER_AZURE_ENDPOINT=https://your-resource.openai.azure.com
-# JOB_SHIT_PROVIDER_AZURE_API_KEY=your-azure-api-key
-# JOB_SHIT_PROVIDER_AZURE_DEFAULT_MODEL=gpt-5-mini
-# JOB_SHIT_PROVIDER_AZURE_MODELS=gpt-5-mini,gpt-4.1-mini
-# JOB_SHIT_PROVIDER_AZURE_API_VERSION=2024-12-01-preview
+# TAILORED_PROVIDER_AZURE_KIND=azure
+# TAILORED_PROVIDER_AZURE_LABEL=Azure OpenAI
+# TAILORED_PROVIDER_AZURE_ENDPOINT=https://your-resource.openai.azure.com
+# TAILORED_PROVIDER_AZURE_API_KEY=your-azure-api-key
+# TAILORED_PROVIDER_AZURE_DEFAULT_MODEL=gpt-5-mini
+# TAILORED_PROVIDER_AZURE_MODELS=gpt-5-mini,gpt-4.1-mini
+# TAILORED_PROVIDER_AZURE_API_VERSION=2024-12-01-preview
 
 # Huntr API token — ONLY needed if you are NOT using huntr-cli.
 # If you have huntr-cli installed and have run `huntr login`, credentials

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Run a single test file: `npx vitest run tests/files.test.ts`
 
 Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level commands:
 
-- **`tailor`** — one-off tailoring from a local JD file: `job-shit tailor --company "Acme" --job jd.txt`
+- **`tailor`** — one-off tailoring from a local JD file: `tailored tailor --company "Acme" --job jd.txt`
 - **`huntr`** — Huntr.co integration subcommands (see below)
 
 ### Core lib (`src/lib/`)
@@ -26,7 +26,7 @@ Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level comman
 - `ai.ts` — thin Anthropic/Claude wrapper (`complete()`, takes an injected client)
 - `tailor.ts` — `tailorDocuments()` fans out resume + cover letter calls via `Promise.all`
 - `prompts.ts` — system/user prompts for resume and cover letter, kept separate
-- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.job-shit/`
+- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.well-tailored/`
 
 ### Commands (`src/commands/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Run a single test file: `npx vitest run tests/files.test.ts`
 
 Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level commands:
 
-- **`tailor`** — one-off tailoring from a local JD file: `job-shit tailor --company "Acme" --job jd.txt`
+- **`tailor`** — one-off tailoring from a local JD file: `tailored tailor --company "Acme" --job jd.txt`
 - **`huntr`** — Huntr.co integration subcommands (see below)
 
 ### Core lib (`src/lib/`)
@@ -26,7 +26,7 @@ Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level comman
 - `ai.ts` — thin Anthropic/Codex wrapper (`complete()`, takes an injected client)
 - `tailor.ts` — `tailorDocuments()` fans out resume + cover letter calls via `Promise.all`
 - `prompts.ts` — system/user prompts for resume and cover letter, kept separate
-- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.job-shit/`
+- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.well-tailored/`
 
 ### Commands (`src/commands/`)
 

--- a/BRAND.md
+++ b/BRAND.md
@@ -1,0 +1,244 @@
+# Well-Tailored Brand Style Guide
+
+## Brand Core
+
+| Attribute | Value |
+|-----------|-------|
+| Brand name | Well-Tailored |
+| Short label | Tailored |
+| Monogram | WT |
+| CLI command | `tailored` |
+| Home directory | `~/.well-tailored/` |
+| Env var prefix | `TAILORED_` |
+
+### Positioning
+
+A polished, modern tool that helps people create better-fit job applications without sounding generic or artificial.
+
+### Personality
+
+Polished, modern, calm, premium, credible. Sharp without being stiff.
+
+### Avoid
+
+- Gimmicky AI aesthetics
+- Loud startup neon palettes
+- Cartoon menswear iconography
+- Corporate-law-firm stiffness
+- Anything that feels like generic HR SaaS
+
+---
+
+## Color System
+
+### Primary Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `text` | `#2B2D33` | Primary text, wordmark |
+| `background` | `#F8F5EE` | Main page background (ivory) |
+| `surface` | `#FFFFFF` | Cards, elevated surfaces |
+| `primary` | `#314A74` | CTAs, links, brand emphasis, icon |
+| `primaryHover` | `#253857` | Hover/active states |
+| `muted` | `#747986` | Secondary/muted text |
+| `border` | `#E3DDD2` | Borders, dividers |
+
+### Usage Rules
+
+- Ivory (`#F8F5EE`) as main page background
+- White for cards and elevated surfaces
+- Charcoal for primary text and wordmarks
+- Navy for important actions, links, and brand emphasis
+- Muted gray only for secondary information
+- Border for subtle structure instead of heavy shadows
+
+---
+
+## Typography
+
+### Font Pairing
+
+| Role | Family | Rationale |
+|------|--------|-----------|
+| Headings | Manrope | Modern, tailored, editorial feel |
+| Body / UI | Inter | Highly readable and practical |
+
+### Scale
+
+| Element | Font | Weight | Size |
+|---------|------|--------|------|
+| H1 | Manrope | 700 | 48-56px |
+| H2 | Manrope | 700 | 36-40px |
+| H3 | Manrope | 600 | 28-32px |
+| H4 | Manrope | 600 | 22-24px |
+| Body Large | Inter | 400 | 18px |
+| Body | Inter | 400 | 16px |
+| Small / Muted | Inter | 400 | 14px |
+| Buttons / Labels | Inter | 600 | 14-16px |
+
+### Rules
+
+- Keep headlines tight and confident
+- Let spacing create the premium feel
+- Avoid all-caps overuse
+- Do not use serif fonts
+
+---
+
+## UI Components
+
+### Buttons
+
+#### Primary
+
+| Property | Value |
+|----------|-------|
+| Background | `#314A74` |
+| Text | `#FFFFFF` |
+| Hover | `#253857` |
+| Radius | 12px |
+| Padding | 12px 18px |
+| Font | Inter 600 |
+| Shadow | Very subtle, if any |
+
+Use for: main CTA, generate/tailor actions, save/export.
+
+#### Secondary
+
+| Property | Value |
+|----------|-------|
+| Background | `#FFFFFF` |
+| Text | `#2B2D33` |
+| Border | `#E3DDD2` |
+| Radius | 12px |
+
+Use for: secondary actions, preview, compare versions.
+
+#### Text Button
+
+| Property | Value |
+|----------|-------|
+| Text | `#314A74` |
+| Background | transparent |
+| Hover | Underline or subtle tint |
+
+Use sparingly.
+
+### Cards
+
+| Property | Value |
+|----------|-------|
+| Background | `#FFFFFF` |
+| Border | 1px solid `#E3DDD2` |
+| Radius | 16px |
+| Padding | 20-24px |
+| Shadow | `0 8px 24px rgba(43, 45, 51, 0.06)` |
+
+Cards should feel like good paper on a desk. Not floating glassmorphism, not dark-mode gamer UI, not default Tailwind cards.
+
+### Inputs
+
+| Property | Value |
+|----------|-------|
+| Background | `#FFFFFF` |
+| Border | `#E3DDD2` |
+| Text | `#2B2D33` |
+| Placeholder | `#747986` |
+| Focus | Softened navy outline |
+| Radius | 10-12px |
+
+---
+
+## Layout Principles
+
+- Generous whitespace
+- Fewer, stronger visual elements
+- Subtle structure over visual noise
+- Premium editorial feel over dashboard clutter
+
+---
+
+## Theme Tokens
+
+```ts
+export const theme = {
+  colors: {
+    text: "#2B2D33",
+    background: "#F8F5EE",
+    surface: "#FFFFFF",
+    primary: "#314A74",
+    primaryHover: "#253857",
+    muted: "#747986",
+    border: "#E3DDD2",
+  },
+  fontFamily: {
+    heading: ["Manrope", "sans-serif"],
+    body: ["Inter", "sans-serif"],
+  },
+  radius: {
+    sm: "10px",
+    md: "12px",
+    lg: "16px",
+    xl: "20px",
+  },
+  shadow: {
+    card: "0 8px 24px rgba(43, 45, 51, 0.06)",
+  },
+};
+```
+
+---
+
+## Logo
+
+### Direction
+
+WT monogram with a subtle lapel-inspired cut or stitch line. Precise, geometric, refined, quietly distinctive.
+
+### System
+
+1. **Primary logo**: Icon + "Well-Tailored" wordmark
+2. **Secondary logo**: Wordmark only
+3. **App icon / favicon**: WT monogram only
+
+### Color Use
+
+| Element | Color |
+|---------|-------|
+| Icon | `#314A74` |
+| Wordmark | `#2B2D33` |
+| Background | `#F8F5EE` or white |
+
+### Wordmark
+
+"Well-Tailored" in Manrope. Title case, slightly open spacing, readable and practical.
+
+### Do Not
+
+- Full suit jacket icons
+- Ties, bowties, or tuxedo clip art
+- Top hats or cartoon monocles
+- Fashion-magazine ultra-thin letterforms
+- Glossy gradients or trendy AI glows
+- Overly ornate luxury branding
+
+### Style Rules
+
+- No gradients
+- No shiny effects
+- No thin fashion-magazine hairlines
+- No clip-art suit icons
+- Clean geometry
+- Medium stroke weight
+- Balanced symmetry with one distinctive cut or angle
+- Simple enough to draw in one color
+
+---
+
+## Hero Copy
+
+**Headline**: Job applications that actually fit.
+
+**Subhead**: Turn your experience and a job description into sharper, more tailored application materials without losing your voice.
+
+**CTAs**: "Tailor my application" / "See an example"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Run a single test file: `npx vitest run tests/files.test.ts`
 
 Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level commands:
 
-- **`tailor`** — one-off tailoring from a local JD file: `job-shit tailor --company "Acme" --job jd.txt`
+- **`tailor`** — one-off tailoring from a local JD file: `tailored tailor --company "Acme" --job jd.txt`
 - **`huntr`** — Huntr.co integration subcommands (see below)
 
 ### Core lib (`src/lib/`)
@@ -26,7 +26,7 @@ Node.js/TypeScript CLI (`src/cli.ts`) built with Commander. Two top-level comman
 - `ai.ts` — thin Anthropic/Claude wrapper (`complete()`, takes an injected client)
 - `tailor.ts` — `tailorDocuments()` fans out resume + cover letter calls via `Promise.all`
 - `prompts.ts` — system/user prompts for resume and cover letter, kept separate
-- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.job-shit/`
+- `files.ts` — `findFile()` auto-discovers `resume*.md` / `bio*.md` from CWD then `~/.well-tailored/`
 
 ### Commands (`src/commands/`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# job-shit
+# Well-Tailored
 
-Stop suffering. Pipe your base resume + company info + job description through AI and get a tailored resume **and** cover letter back — in parallel — without touching them yourself.
+Job applications that actually fit. Turn your experience and a job description into sharper, more tailored application materials without losing your voice.
 
 ## How it works
 
@@ -48,11 +48,11 @@ npm run build
 ### Tailor resume + cover letter for a job
 
 ```bash
-# Minimal — resume and bio are auto-detected from CWD or ~/.job-shit/
-job-shit tailor --company "Acme Corp" --job jd.txt
+# Minimal — resume and bio are auto-detected from CWD or ~/.well-tailored/
+tailored tailor --company "Acme Corp" --job jd.txt
 
 # Full options
-job-shit tailor \
+tailored tailor \
   --company "Acme Corp" \
   --job jd.txt \
   --title "Senior Software Engineer" \
@@ -73,25 +73,25 @@ PDF generation requires Google Chrome installed.
 
 | File | Purpose | Auto-discovery |
 |------|---------|----------------|
-| `resume*.md` | Base resume (markdown) | CWD, then `~/.job-shit/` — most recently modified wins |
-| `bio*.md` | Personal background blurb | CWD, then `~/.job-shit/` |
-| `cover-letter*.md` | Voice/tone reference for cover letter | CWD, then `~/.job-shit/` — optional |
-| `resume-supplemental*.md` | Extra factual context for AI | CWD, then `~/.job-shit/` — optional |
+| `resume*.md` | Base resume (markdown) | CWD, then `~/.well-tailored/` — most recently modified wins |
+| `bio*.md` | Personal background blurb | CWD, then `~/.well-tailored/` |
+| `cover-letter*.md` | Voice/tone reference for cover letter | CWD, then `~/.well-tailored/` — optional |
+| `resume-supplemental*.md` | Extra factual context for AI | CWD, then `~/.well-tailored/` — optional |
 
 ### Huntr.co integration
 
 ```bash
 # List jobs in your Wishlist (not yet applied to)
-job-shit huntr wishlist
+tailored huntr wishlist
 
 # List all jobs across boards with their current stage
-job-shit huntr jobs
+tailored huntr jobs
 
 # Tailor a specific job (board auto-detected)
-job-shit huntr tailor <jobId>
+tailored huntr tailor <jobId>
 
 # Tailor every Wishlist job in one shot
-job-shit huntr tailor-all
+tailored huntr tailor-all
 ```
 
 **Credentials** are resolved automatically in this order:
@@ -124,10 +124,10 @@ Optional:
 | `AZURE_OPENAI_API_VERSION` | Azure API version (default: `2024-12-01-preview`) |
 | `OPENAI_BASE_URL` | Custom base URL for OpenAI-compatible endpoints |
 | `OPENAI_PROVIDER_NAME` | Friendly label for the OpenAI-compatible provider (for example `Grok`) |
-| `JOB_SHIT_PROVIDER` | Default provider for the workbench (`gemini`, `azure`, `openai`, `anthropic`) |
-| `JOB_SHIT_TAILORING_PROVIDER` / `JOB_SHIT_SCORING_PROVIDER` | Per-task provider defaults |
-| `JOB_SHIT_AZURE_MODELS` | Comma-separated Azure deployment names to show in the selector |
-| `JOB_SHIT_OPENAI_MODELS` / `JOB_SHIT_GEMINI_MODELS` / `JOB_SHIT_ANTHROPIC_MODELS` | Extra provider-specific model choices |
+| `TAILORED_PROVIDER` | Default provider for the workbench (`gemini`, `azure`, `openai`, `anthropic`) |
+| `TAILORED_TAILORING_PROVIDER` / `TAILORED_SCORING_PROVIDER` | Per-task provider defaults |
+| `TAILORED_AZURE_MODELS` | Comma-separated Azure deployment names to show in the selector |
+| `TAILORED_OPENAI_MODELS` / `TAILORED_GEMINI_MODELS` / `TAILORED_ANTHROPIC_MODELS` | Extra provider-specific model choices |
 | `HUNTR_API_TOKEN` | Huntr token (if not using huntr-cli credentials) |
 
 Notes:
@@ -141,29 +141,29 @@ If you want several providers side by side, especially multiple OpenAI-compatibl
 official OpenAI plus Groq, use named profiles:
 
 ```env
-JOB_SHIT_PROVIDER_PROFILES=openai,groq,azure,anthropic
+TAILORED_PROVIDER_PROFILES=openai,groq,azure,anthropic
 
-JOB_SHIT_PROVIDER_OPENAI_KIND=openai
-JOB_SHIT_PROVIDER_OPENAI_LABEL=OpenAI
-JOB_SHIT_PROVIDER_OPENAI_API_KEY=...
-JOB_SHIT_PROVIDER_OPENAI_DEFAULT_MODEL=gpt-5-mini
+TAILORED_PROVIDER_OPENAI_KIND=openai
+TAILORED_PROVIDER_OPENAI_LABEL=OpenAI
+TAILORED_PROVIDER_OPENAI_API_KEY=...
+TAILORED_PROVIDER_OPENAI_DEFAULT_MODEL=gpt-5-mini
 
-JOB_SHIT_PROVIDER_GROQ_KIND=openai
-JOB_SHIT_PROVIDER_GROQ_LABEL=Groq
-JOB_SHIT_PROVIDER_GROQ_API_KEY=...
-JOB_SHIT_PROVIDER_GROQ_BASE_URL=https://api.groq.com/openai/v1
-JOB_SHIT_PROVIDER_GROQ_DEFAULT_MODEL=llama-3.3-70b-versatile
+TAILORED_PROVIDER_GROQ_KIND=openai
+TAILORED_PROVIDER_GROQ_LABEL=Groq
+TAILORED_PROVIDER_GROQ_API_KEY=...
+TAILORED_PROVIDER_GROQ_BASE_URL=https://api.groq.com/openai/v1
+TAILORED_PROVIDER_GROQ_DEFAULT_MODEL=llama-3.3-70b-versatile
 
-JOB_SHIT_PROVIDER_AZURE_KIND=azure
-JOB_SHIT_PROVIDER_AZURE_LABEL=Azure OpenAI
-JOB_SHIT_PROVIDER_AZURE_ENDPOINT=https://your-resource.openai.azure.com
-JOB_SHIT_PROVIDER_AZURE_API_KEY=...
-JOB_SHIT_PROVIDER_AZURE_DEFAULT_MODEL=gpt-5-mini
+TAILORED_PROVIDER_AZURE_KIND=azure
+TAILORED_PROVIDER_AZURE_LABEL=Azure OpenAI
+TAILORED_PROVIDER_AZURE_ENDPOINT=https://your-resource.openai.azure.com
+TAILORED_PROVIDER_AZURE_API_KEY=...
+TAILORED_PROVIDER_AZURE_DEFAULT_MODEL=gpt-5-mini
 
-JOB_SHIT_PROVIDER_ANTHROPIC_KIND=anthropic
-JOB_SHIT_PROVIDER_ANTHROPIC_LABEL=Anthropic
-JOB_SHIT_PROVIDER_ANTHROPIC_API_KEY=...
-JOB_SHIT_PROVIDER_ANTHROPIC_DEFAULT_MODEL=claude-sonnet-4-5
+TAILORED_PROVIDER_ANTHROPIC_KIND=anthropic
+TAILORED_PROVIDER_ANTHROPIC_LABEL=Anthropic
+TAILORED_PROVIDER_ANTHROPIC_API_KEY=...
+TAILORED_PROVIDER_ANTHROPIC_DEFAULT_MODEL=claude-sonnet-4-5
 ```
 
 Each profile gets its own label, credentials, default model, and model list. The workbench provider

--- a/docs/generation-flow-landscape.html
+++ b/docs/generation-flow-landscape.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>generation flow · landscape · job-shit</title>
+  <title>generation flow · landscape · Well-Tailored</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
@@ -475,7 +475,7 @@
 
   <!-- ── Header ───────────────────────────────── -->
   <div class="header">
-    <div class="header-eyebrow">job-shit · architecture · landscape</div>
+    <div class="header-eyebrow">Well-Tailored · architecture · landscape</div>
     <h1 class="header-title">Generation Flow</h1>
     <p class="header-sub">Two workflows, one pipeline — left to right. Job application above; stack resume maintenance below.</p>
   </div>

--- a/docs/generation-flow.html
+++ b/docs/generation-flow.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>generation flow · job-shit</title>
+  <title>generation flow · Well-Tailored</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
@@ -627,7 +627,7 @@
 
   <!-- ── Header ───────────────────────────────── -->
   <div class="header">
-    <div class="header-eyebrow">job-shit · architecture</div>
+    <div class="header-eyebrow">Well-Tailored · architecture</div>
     <h1 class="header-title">Generation Flow</h1>
     <p class="header-sub">From job discovery to tailored resume &amp; cover letter — two paths in, one pipeline out.<br>Stack resumes run as a parallel maintenance track.</p>
   </div>
@@ -651,7 +651,7 @@
         <div class="path-card">
           <div class="path-card-head">
             <span class="path-tag">manual</span>
-            <span class="path-cmd">job-shit tailor</span>
+            <span class="path-cmd">tailored tailor</span>
           </div>
           <div class="path-body">
             <div class="user-block">
@@ -691,7 +691,7 @@
                 </div>
               </div>
             </div>
-            <p class="note">files auto-discovered · CWD → ~/.job-shit/</p>
+            <p class="note">files auto-discovered · CWD → ~/.well-tailored/</p>
           </div>
         </div>
 
@@ -699,7 +699,7 @@
         <div class="path-card">
           <div class="path-card-head">
             <span class="path-tag">huntr</span>
-            <span class="path-cmd">job-shit huntr tailor[-all]</span>
+            <span class="path-cmd">tailored huntr tailor[-all]</span>
           </div>
           <div class="path-body">
             <div class="user-block">

--- a/docs/plans/2026-03-15-diff-gap-tui-design.md
+++ b/docs/plans/2026-03-15-diff-gap-tui-design.md
@@ -13,10 +13,10 @@ Shows what the AI changed from the base resume to the tailored version. Supports
 ### CLI surface
 ```bash
 # After tailoring, automatically show a summary:
-job-shit tailor --company "Acme" --job jd.txt --diff
+tailored tailor --company "Acme" --job jd.txt --diff
 
 # Compare two saved versions:
-job-shit diff <jobId> --v1 0 --v2 1
+tailored diff <jobId> --v1 0 --v2 1
 ```
 
 Terminal output uses ANSI colors: green for additions, red for removals, gray for unchanged context. Line-level diff with word-level highlighting within changed lines.
@@ -83,13 +83,13 @@ Before tailoring, analyzes the JD against the base resume and surfaces:
 ### CLI surface
 ```bash
 # Standalone analysis:
-job-shit gap --job jd.txt
+tailored gap --job jd.txt
 
 # Automatically shown before tailoring (opt-out):
-job-shit tailor --company "Acme" --job jd.txt  # shows gap summary, then tailors
+tailored tailor --company "Acme" --job jd.txt  # shows gap summary, then tailors
 
 # Huntr integration:
-job-shit huntr gap <jobId>
+tailored huntr gap <jobId>
 ```
 
 ### Workbench surface
@@ -165,10 +165,10 @@ After generation, lets you review the tailored resume section-by-section, accept
 ### CLI surface
 ```bash
 # Enter interactive mode after tailoring:
-job-shit tailor --company "Acme" --job jd.txt --interactive
+tailored tailor --company "Acme" --job jd.txt --interactive
 
 # Review an existing result:
-job-shit review <jobId>
+tailored review <jobId>
 ```
 
 ### Terminal TUI (Ink)

--- a/docs/plans/2026-03-16-workbench-v2-design.md
+++ b/docs/plans/2026-03-16-workbench-v2-design.md
@@ -19,7 +19,7 @@ Redesign the workbench into a focused, single-screen workflow: select jobs, tail
 
 ```
 +--------+------------------------------------------------------------+
-| WORKSPACE [autocomplete/dropdown] [Save] [Delete]  [gear] ~/.job-shit|
+| WORKSPACE [autocomplete/dropdown] [Save] [Delete]  [gear] ~/.well-tailored|
 +--+-----+---------------------------+-------------------+-----------+
 |  |  SCORE CARDS                    | ANALYSIS NOTES                |
 |J |  Resume: 8  Cover: 7  Acc: 6   | Reviewer notes, fit, risk     |
@@ -58,11 +58,11 @@ Clicking an icon slides a ~300px panel in/out. Main review area compresses but s
 - **Delete** — available after loading a workspace. Confirms before deleting.
 - **Copy** — type a new name in the autocomplete field, copy button glows/animates to confirm.
 - **Gear icon** — opens config slide-out.
-- **Storage indicator** — subtle `~/.job-shit` label in the corner. All data (workspaces, config) lives there.
+- **Storage indicator** — subtle `~/.well-tailored` label in the corner. All data (workspaces, config) lives there.
 
 ### Workspace Management
 
-- Workspaces save to `~/.job-shit/workspaces/`.
+- Workspaces save to `~/.well-tailored/workspaces/`.
 - Create, load, save, copy (with animated confirmation), delete.
 - **Export** — download workspace as `.zip` (JSON state + generated outputs) for backup/sharing.
 - Path shown subtly so power users know where to find files on disk.
@@ -207,12 +207,12 @@ Tailor -> Review scores -> Edit sections -> Scores show "-> ?"
 
 ## Data & Storage
 
-- All data in `~/.job-shit/`:
+- All data in `~/.well-tailored/`:
   - `workspaces/` — workspace JSON files with state.
   - `config.json` — API keys, model preferences, prompt overrides.
   - Generated outputs per workspace.
 - Workspace export as `.zip` for backup.
-- Subtle `~/.job-shit` storage indicator always visible.
+- Subtle `~/.well-tailored` storage indicator always visible.
 
 ## Button Activation Pattern
 

--- a/docs/plans/2026-03-16-workbench-v2-implementation.md
+++ b/docs/plans/2026-03-16-workbench-v2-implementation.md
@@ -35,7 +35,7 @@ Create `src/workbench/index-v2.html` with the full layout structure but no JS lo
     <button class="btn-icon" id="exportWorkspaceBtn" disabled>Export</button>
   </div>
   <div class="top-bar__right">
-    <span class="storage-indicator">~/.job-shit</span>
+    <span class="storage-indicator">~/.well-tailored</span>
   </div>
 </div>
 

--- a/docs/plans/2026-03-16-workbench-v2-unified-review-panel.md
+++ b/docs/plans/2026-03-16-workbench-v2-unified-review-panel.md
@@ -13,7 +13,7 @@ and missing keyword sidebar.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ WORKSPACE [autocomplete▾] [Save] [Delete]    [⚙]    💾 ~/.job-shit     │
+│ WORKSPACE [autocomplete▾] [Save] [Delete]    [⚙]    💾 ~/.well-tailored     │
 ├──┬──────────────────────────────────────────────────────────────────────┤
 │  │ ┌─ SCORE CARDS ──────────────┬─ ANALYSIS NOTES ───────────────────┐ │
 │J │ │ Resume: 8  Cover: 7  ...   │ Reviewer notes, accuracy, etc     │ │
@@ -141,7 +141,7 @@ Above each section's fields, colored pills show:
 - **Delete** — available after loading a workspace
 - **Copy** — type new name in autocomplete field, action button glows
 - **Export** — download workspace as `.zip` (JSON + outputs)
-- **Path label:** `💾 ~/.job-shit` always visible in corner
+- **Path label:** `💾 ~/.well-tailored` always visible in corner
 - Buttons activate/deactivate based on context (no dead buttons)
 
 ## Files

--- a/docs/workbench-flow.html
+++ b/docs/workbench-flow.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>workbench flow · job-shit</title>
+  <title>workbench flow · Well-Tailored</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
@@ -600,7 +600,7 @@
 
   <!-- ── Header ───────────────────────────────── -->
   <div class="header">
-    <div class="header-eyebrow">job-shit · architecture</div>
+    <div class="header-eyebrow">Well-Tailored · architecture</div>
     <h1 class="header-title">Workbench Flow</h1>
     <p class="header-sub">Browser-based resume workbench — Express server + single-page app.<br>Sources in, AI tailoring, structured editing, scored preview out.</p>
   </div>
@@ -650,7 +650,7 @@
               <div class="path-row">cover-letter*.md (opt)</div>
               <div class="path-row">resume-supplemental*.md (opt)</div>
             </div>
-            <p class="note">CWD → ~/.job-shit/ fallback</p>
+            <p class="note">CWD → ~/.well-tailored/ fallback</p>
           </div>
         </div>
 
@@ -1036,7 +1036,7 @@
 
   <!-- ── Workspace Persistence ───────────────── -->
   <div class="flow-item" style="animation-delay:0.32s; margin-top: 32px;">
-    <div class="section-eyebrow">Workspace Persistence · ~/.job-shit/workspaces/</div>
+    <div class="section-eyebrow">Workspace Persistence · ~/.well-tailored/workspaces/</div>
     <div class="card" style="padding:24px 28px">
       <div class="pipeline" style="margin-bottom:16px">
         <span class="pl-step">Browser state</span>

--- a/docs/workbench-promo-edit-handoff.md
+++ b/docs/workbench-promo-edit-handoff.md
@@ -143,7 +143,7 @@ This is what creates the Codex-like pull-through feeling.
   - Nearly static
   - Tiny ambient drift only
 - Overlay copy:
-  - `job-shit workbench`
+  - `Well-Tailored workbench`
   - `A sharper application loop`
 - End behavior:
   - fade to black or loop back to Scene 1 close-up

--- a/docs/workbench-promo-storyboard.md
+++ b/docs/workbench-promo-storyboard.md
@@ -133,7 +133,7 @@ The cut should feel editorial and cinematic, not tutorial-like.
 - Framing: clean branded frame built from the best wide shot, slightly darkened.
 - Camera move: nearly static, tiny drift only.
 - On-screen copy:
-  - `job-shit workbench`
+  - `Well-Tailored workbench`
   - `A sharper application loop`
 - Purpose: clean landing and loop point.
 

--- a/docs/workbench-promo-video-guide.md
+++ b/docs/workbench-promo-video-guide.md
@@ -17,26 +17,26 @@ For the video itself, the practical path is:
 ### 1. Generate the screenshot pack
 
 ```bash
-cd /Users/matt.mcknight/job-shit
+cd /Users/matt.mcknight/well-tailored
 npm run shots:workbench -- --headed
 ```
 
 Outputs land in:
 
-- `/Users/matt.mcknight/job-shit/output/playwright/workbench-shots`
+- `/Users/matt.mcknight/well-tailored/output/playwright/workbench-shots`
 
 ### 2. Build a rough animatic
 
 This creates a simple timing video from the screenshot pack:
 
 ```bash
-cd /Users/matt.mcknight/job-shit
+cd /Users/matt.mcknight/well-tailored
 npm run video:promo
 ```
 
 Output:
 
-- `/Users/matt.mcknight/job-shit/output/video/workbench-promo-animatic.mp4`
+- `/Users/matt.mcknight/well-tailored/output/video/workbench-promo-animatic.mp4`
 
 This is not the final cinematic cut. It is a timing/assembly pass so you can:
 - sanity-check pacing
@@ -46,9 +46,9 @@ This is not the final cinematic cut. It is a timing/assembly pass so you can:
 ### 3. Open the planning docs
 
 ```bash
-open /Users/matt.mcknight/job-shit/docs/workbench-promo-shot-map.md
-open /Users/matt.mcknight/job-shit/docs/workbench-promo-voiceover.md
-open /Users/matt.mcknight/job-shit/docs/workbench-promo-edit-handoff.md
+open /Users/matt.mcknight/well-tailored/docs/workbench-promo-shot-map.md
+open /Users/matt.mcknight/well-tailored/docs/workbench-promo-voiceover.md
+open /Users/matt.mcknight/well-tailored/docs/workbench-promo-edit-handoff.md
 ```
 
 ## Recommended Final-Cut Workflow: Descript
@@ -128,8 +128,8 @@ That would give you:
 If you want the shortest possible sequence:
 
 ```bash
-cd /Users/matt.mcknight/job-shit
+cd /Users/matt.mcknight/well-tailored
 npm run shots:workbench -- --headed
 npm run video:promo
-open /Users/matt.mcknight/job-shit/output/video/workbench-promo-animatic.mp4
+open /Users/matt.mcknight/well-tailored/output/video/workbench-promo-animatic.mp4
 ```

--- a/docs/workbench-promo-voiceover.md
+++ b/docs/workbench-promo-voiceover.md
@@ -54,13 +54,13 @@ Use this as the narration bed for the promo. It is written to match the existing
 ### Scene 10
 - Time: `0:56-1:00`
 - Read:
-  `The job-shit workbench. A sharper application loop.`
+  `The Well-Tailored workbench. A sharper application loop.`
 
 ## Single-Pass Script
 
 Use this version if you want the whole thing in one block for recording:
 
-`Job applications usually fall apart in the last mile. So we built one workbench for the whole tailoring loop. Start from your own materials, a Huntr wishlist role, or a pasted brief, without bouncing between tools. Pull a real job in fast, keep the context visible, and stage the run from a single surface. Models, prompts, and review logic stay adjustable right where the work happens. You can tune the output itself too, not just the words behind it. When the pass finishes, it comes back with fit, ATS signal, findings, and live preview, not just text. Ingest, direct, evaluate, and export, all in one connected workflow. Then hand off clean markdown, HTML, or PDF when it is ready to send. The job-shit workbench. A sharper application loop.`
+`Job applications usually fall apart in the last mile. So we built one workbench for the whole tailoring loop. Start from your own materials, a Huntr wishlist role, or a pasted brief, without bouncing between tools. Pull a real job in fast, keep the context visible, and stage the run from a single surface. Models, prompts, and review logic stay adjustable right where the work happens. You can tune the output itself too, not just the words behind it. When the pass finishes, it comes back with fit, ATS signal, findings, and live preview, not just text. Ingest, direct, evaluate, and export, all in one connected workflow. Then hand off clean markdown, HTML, or PDF when it is ready to send. The Well-Tailored workbench. A sharper application loop.`
 
 ## Delivery Notes
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
-  "name": "job-shit",
+  "name": "well-tailored",
   "version": "1.0.0",
-  "description": "Resume and cover letter tailoring workflow. Base resume + company info + job description → tailored resume + cover letter, in parallel.",
+  "description": "Job applications that actually fit. Resume + company + job description → tailored resume + cover letter, in parallel.",
   "type": "module",
   "bin": {
-    "job-shit": "./dist/cli.js"
+    "tailored": "./dist/cli.js"
   },
   "scripts": {
     "build": "tsc && node scripts/copy-assets.mjs",
     "dev": "tsx src/cli.ts",
     "serve": "tsx src/cli.ts serve",
-    "shit": "tsx src/cli.ts serve",
     "shots:workbench": "node scripts/capture-workbench-shots.mjs",
     "video:promo": "node scripts/build-workbench-promo.mjs",
     "lint": "eslint src",
@@ -19,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mattmck/job-shit.git"
+    "url": "git+https://github.com/mattmck/well-tailored.git"
   },
   "keywords": [
     "resume",
@@ -35,9 +34,9 @@
     "node": ">=20.19.0"
   },
   "bugs": {
-    "url": "https://github.com/mattmck/job-shit/issues"
+    "url": "https://github.com/mattmck/well-tailored/issues"
   },
-  "homepage": "https://github.com/mattmck/job-shit#readme",
+  "homepage": "https://github.com/mattmck/well-tailored#readme",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "commander": "^14.0.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,9 +25,9 @@ function getVersion(): string {
 const program = new Command();
 
 program
-  .name('job-shit')
+  .name('tailored')
   .description(
-    'Stop suffering. Base resume + company + job description → tailored resume + cover letter, in parallel.',
+    'Job applications that actually fit. Resume + company + job description → tailored resume + cover letter, in parallel.',
   )
   .version(getVersion());
 

--- a/src/commands/gap.ts
+++ b/src/commands/gap.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { loadConfig } from '../config.js';
 import { analyzeGap, analyzeGapWithAI } from '../services/gap.js';
-import { findFile, JOB_SHIT_DIR, readFile } from '../lib/files.js';
+import { findFile, TAILORED_DIR, readFile } from '../lib/files.js';
 import { EnrichedGapAnalysis, GapAnalysis } from '../types/index.js';
 
 const ANSI = {
@@ -78,11 +78,11 @@ export function registerGapCommand(program: Command): void {
     .requiredOption('-j, --job <file>', 'Path to job description file (plain text or markdown)')
     .option(
       '-r, --resume <file>',
-      `Path to base resume file (markdown). Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Path to base resume file (markdown). Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option(
       '-b, --bio <file>',
-      `Path to personal bio/background file. Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted when --ai is used.`,
+      `Path to personal bio/background file. Auto-detected from CWD or ${TAILORED_DIR} if omitted when --ai is used.`,
     )
     .option('-t, --title <title>', 'Job title (optional, included in the analysis)')
     .option('--ai', 'Use AI to add a narrative summary and tailoring hints')

--- a/src/commands/huntr.ts
+++ b/src/commands/huntr.ts
@@ -8,7 +8,7 @@ import { tailorDocuments } from '../lib/tailor.js';
 import { logUsingEntries } from '../lib/logging.js';
 import { describeProvider } from '../lib/ai.js';
 import { withSpinner } from '../lib/spinner.js';
-import { findFile, readFile, JOB_SHIT_DIR } from '../lib/files.js';
+import { findFile, readFile, TAILORED_DIR } from '../lib/files.js';
 import { renderResumeHtml, renderCoverLetterHtml, renderPdf, renderResumePdfFit } from '../lib/render.js';
 import { analyzeGap, analyzeGapWithAI } from '../services/gap.js';
 import { launchReviewTui } from '../tui/review.js';
@@ -295,11 +295,11 @@ export function registerHuntrCommand(program: Command): void {
     .option('--board <boardId>', 'Huntr board ID (auto-detected if omitted)')
     .option(
       '-r, --resume <file>',
-      `Base resume file (markdown). Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Base resume file (markdown). Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option(
       '-b, --bio <file>',
-      `Personal bio file. Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted when --ai is used.`,
+      `Personal bio file. Auto-detected from CWD or ${TAILORED_DIR} if omitted when --ai is used.`,
     )
     .option('--ai', 'Use AI to add a narrative summary and tailoring hints')
     .option('-m, --model <model>', 'Model/deployment name for AI-enriched gap analysis')
@@ -336,11 +336,11 @@ export function registerHuntrCommand(program: Command): void {
     .option('--board <boardId>', 'Huntr board ID (auto-detected if omitted)')
     .option(
       '-r, --resume <file>',
-      `Base resume file (markdown). Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Base resume file (markdown). Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option(
       '-b, --bio <file>',
-      `Personal bio file. Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Personal bio file. Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option('-s, --supplemental <file>', 'Supplemental resume file (markdown). Auto-detected if omitted.')
     .option('-o, --output <dir>', 'Output directory', 'output')
@@ -406,11 +406,11 @@ export function registerHuntrCommand(program: Command): void {
     .option('--board <boardId>', 'Limit to a specific board ID')
     .option(
       '-r, --resume <file>',
-      `Base resume file (markdown). Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Base resume file (markdown). Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option(
       '-b, --bio <file>',
-      `Personal bio file. Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Personal bio file. Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option('-s, --supplemental <file>', 'Supplemental resume file (markdown). Auto-detected if omitted.')
     .option('-o, --output <dir>', 'Output directory', 'output')

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -4,7 +4,7 @@ import { startWorkbenchServer } from '../server.js';
 export function registerServeCommand(program: Command): void {
   program
     .command('serve')
-    .description('Run the local job-shit workbench and API server.')
+    .description('Run the local Well-Tailored workbench and API server.')
     .option('-p, --port <port>', 'Port to listen on', '4312')
     .action(async (opts: { port: string }) => {
       const port = parseInt(opts.port, 10);
@@ -13,6 +13,6 @@ export function registerServeCommand(program: Command): void {
         process.exit(1);
       }
       const { port: actualPort } = await startWorkbenchServer(port);
-      console.log(`job-shit workbench listening on http://localhost:${actualPort}`);
+      console.log(`Well-Tailored workbench listening on http://localhost:${actualPort}`);
     });
 }

--- a/src/commands/tailor.ts
+++ b/src/commands/tailor.ts
@@ -8,7 +8,7 @@ import { tailorDocuments } from '../lib/tailor.js';
 import { logUsingEntries } from '../lib/logging.js';
 import { describeProvider } from '../lib/ai.js';
 import { withSpinner } from '../lib/spinner.js';
-import { findFile, readFile, JOB_SHIT_DIR } from '../lib/files.js';
+import { findFile, readFile, TAILORED_DIR } from '../lib/files.js';
 import { renderResumeHtml, renderCoverLetterHtml, renderPdf, renderResumePdfFit } from '../lib/render.js';
 import { analyzeGapWithAI } from '../services/gap.js';
 import { launchReviewTui } from '../tui/review.js';
@@ -28,11 +28,11 @@ export function registerTailorCommand(program: Command): void {
     .requiredOption('-j, --job <file>', 'Path to job description file (plain text or markdown)')
     .option(
       '-r, --resume <file>',
-      `Path to base resume file (markdown). Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Path to base resume file (markdown). Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option(
       '-b, --bio <file>',
-      `Path to personal bio/background file. Auto-detected from CWD or ${JOB_SHIT_DIR} if omitted.`,
+      `Path to personal bio/background file. Auto-detected from CWD or ${TAILORED_DIR} if omitted.`,
     )
     .option('-s, --supplemental <file>', 'Supplemental resume file (markdown). Auto-detected if omitted.')
     .option('-t, --title <title>', 'Job title (inferred from JD if omitted)')

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,7 +139,7 @@ async function resolveHuntrClerkToken(): Promise<string | undefined> {
  *   2. ~/.huntr/config.json (static token set via `huntr config set-token`)
  *   3. Keychain static api-token (set via `huntr config set-token --keychain`)
  *   4. Clerk session (set via `huntr login`) — refreshes automatically
- *   5. HUNTR_TOKEN env var (job-shit backward compat)
+ *   5. HUNTR_TOKEN env var (legacy backward compat)
  */
 export async function resolveHuntrToken(): Promise<string | undefined> {
   if (process.env.HUNTR_API_TOKEN) return process.env.HUNTR_API_TOKEN;
@@ -193,32 +193,32 @@ function modelsForProvider(
 
 export function loadConfig(): Config {
   const providers = listConfiguredProviders();
-  const preferredProvider = normalizeProviderChoice(process.env.JOB_SHIT_PROVIDER);
+  const preferredProvider = normalizeProviderChoice(process.env.TAILORED_PROVIDER);
   const tailoringProvider = defaultProvider(
     providers,
-    normalizeProviderChoice(process.env.JOB_SHIT_TAILORING_PROVIDER) ?? preferredProvider,
+    normalizeProviderChoice(process.env.TAILORED_TAILORING_PROVIDER) ?? preferredProvider,
   );
   const scoringProvider = defaultProvider(
     providers,
-    normalizeProviderChoice(process.env.JOB_SHIT_SCORING_PROVIDER) ?? preferredProvider ?? tailoringProvider,
+    normalizeProviderChoice(process.env.TAILORED_SCORING_PROVIDER) ?? preferredProvider ?? tailoringProvider,
   );
-  const sharedDefault = process.env.JOB_SHIT_MODEL
+  const sharedDefault = process.env.TAILORED_MODEL
     ?? (tailoringProvider === 'auto'
       ? providers[0]?.defaultModel
       : providers.find((provider) => provider.id === tailoringProvider)?.defaultModel)
     ?? 'auto';
-  const tailoringModel = process.env.JOB_SHIT_TAILORING_MODEL ?? sharedDefault;
-  const scoringModel = process.env.JOB_SHIT_SCORING_MODEL ?? process.env.JOB_SHIT_MODEL ?? tailoringModel;
+  const tailoringModel = process.env.TAILORED_TAILORING_MODEL ?? sharedDefault;
+  const scoringModel = process.env.TAILORED_SCORING_MODEL ?? process.env.TAILORED_MODEL ?? tailoringModel;
   const tailoringModels = modelsForProvider(
     providers,
     tailoringProvider,
-    parseModelList(process.env.JOB_SHIT_TAILORING_MODELS),
+    parseModelList(process.env.TAILORED_TAILORING_MODELS),
     tailoringModel,
   );
   const scoringModels = modelsForProvider(
     providers,
     scoringProvider,
-    parseModelList(process.env.JOB_SHIT_SCORING_MODELS),
+    parseModelList(process.env.TAILORED_SCORING_MODELS),
     scoringModel,
   );
 

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -2,14 +2,14 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 
-/** Default directory where job-shit looks for base files. */
-export const JOB_SHIT_DIR = join(homedir(), '.job-shit');
+/** Default directory where Well-Tailored looks for base files. */
+export const TAILORED_DIR = join(homedir(), '.well-tailored');
 
 /** Local directory for prompt overrides (ignored by git). */
 export const PROMPT_DIR = 'prompts';
 
 /** Global directory for prompt overrides. */
-export const PROMPTS_GLOBAL_DIR = join(JOB_SHIT_DIR, 'prompts');
+export const PROMPTS_GLOBAL_DIR = join(TAILORED_DIR, 'prompts');
 
 /**
  * Find the most recently modified file matching a glob-like basename pattern.
@@ -47,7 +47,7 @@ function findLatestIn(dir: string, prefix: string, ext: string): string | null {
  * Resolution order (stops at first hit):
  *   1. Explicit path (if provided via CLI flag)
  *   2. Current directory — exact match (prefix+ext), then newest prefix+ext (ignoring samples)
- *   3. ~/.job-shit/    — exact match (prefix+ext), then newest prefix+ext (ignoring samples)
+ *   3. ~/.well-tailored/ — exact match (prefix+ext), then newest prefix+ext (ignoring samples)
  *
  * Returns the resolved path string, or throws if nothing is found.
  *
@@ -76,13 +76,13 @@ export function findFile(opts: {
   const cwdMatch = findLatestIn(cwd, opts.prefix, ext);
   if (cwdMatch) return cwdMatch;
 
-  // 3. ~/.job-shit/
-  const homeMatch = findLatestIn(JOB_SHIT_DIR, opts.prefix, ext);
+  // 3. ~/.well-tailored/
+  const homeMatch = findLatestIn(TAILORED_DIR, opts.prefix, ext);
   if (homeMatch) return homeMatch;
 
   throw new Error(
     `No ${opts.label} file found. ` +
-      `Create '${opts.prefix}${ext}' in the current directory or in ${JOB_SHIT_DIR}.`,
+      `Create '${opts.prefix}${ext}' in the current directory or in ${TAILORED_DIR}.`,
   );
 }
 
@@ -93,7 +93,7 @@ export function readFile(filePath: string): string {
 
 /**
  * Load a prompt from a file, with fallbacks.
- * Checks local 'prompts/' directory then global '~/.job-shit/prompts/'.
+ * Checks local 'prompts/' directory then global '~/.well-tailored/prompts/'.
  * Returns the provided default if no file is found.
  */
 export function loadPrompt(filename: string, defaultValue: string): string {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -64,22 +64,22 @@ export function normalizeProviderChoice(value?: string): ProviderChoice | undefi
 }
 
 function sharedModelChoices(): string[] {
-  return parseList(process.env.JOB_SHIT_MODELS);
+  return parseList(process.env.TAILORED_MODELS);
 }
 
 function legacyProviderModels(kind: ProviderKind): string[] {
   switch (kind) {
     case 'gemini':
-      return parseList(process.env.JOB_SHIT_GEMINI_MODELS);
+      return parseList(process.env.TAILORED_GEMINI_MODELS);
     case 'azure':
       return unique([
-        ...parseList(process.env.JOB_SHIT_AZURE_MODELS),
-        ...parseList(process.env.JOB_SHIT_AZURE_OPENAI_MODELS),
+        ...parseList(process.env.TAILORED_AZURE_MODELS),
+        ...parseList(process.env.TAILORED_AZURE_OPENAI_MODELS),
       ]);
     case 'openai':
-      return parseList(process.env.JOB_SHIT_OPENAI_MODELS);
+      return parseList(process.env.TAILORED_OPENAI_MODELS);
     case 'anthropic':
-      return parseList(process.env.JOB_SHIT_ANTHROPIC_MODELS);
+      return parseList(process.env.TAILORED_ANTHROPIC_MODELS);
   }
 }
 
@@ -144,7 +144,7 @@ function legacyProviders(): ResolvedProvider[] {
 
 function namedProvider(id: string): ResolvedProvider | undefined {
   const token = envToken(id);
-  const prefix = `JOB_SHIT_PROVIDER_${token}_`;
+  const prefix = `TAILORED_PROVIDER_${token}_`;
   const kind = normalizeKind(process.env[`${prefix}KIND`]);
   if (!kind) return undefined;
 
@@ -220,7 +220,7 @@ function namedProvider(id: string): ResolvedProvider | undefined {
 }
 
 function namedProviders(): ResolvedProvider[] {
-  return parseList(process.env.JOB_SHIT_PROVIDER_PROFILES)
+  return parseList(process.env.TAILORED_PROVIDER_PROFILES)
     .map((id) => namedProvider(id.toLowerCase()))
     .filter((provider): provider is ResolvedProvider => Boolean(provider));
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -192,7 +192,7 @@ async function buildPdfBuffer(body: ExportPdfBody): Promise<{ filename: string; 
     throw new Error(`Unknown export kind: ${body.kind}`);
   }
 
-  const dir = mkdtempSync(join(tmpdir(), 'job-shit-export-'));
+  const dir = mkdtempSync(join(tmpdir(), 'well-tailored-export-'));
   try {
     const htmlPath = join(dir, `${body.kind}.html`);
     const pdfPath = join(dir, `${body.kind}.pdf`);
@@ -461,7 +461,7 @@ async function handleApi(req: IncomingMessage, res: ServerResponse): Promise<voi
     }
 
     const cwd = process.cwd();
-    const home = join(homedir(), '.job-shit');
+    const home = join(homedir(), '.well-tailored');
 
     // Normalize allowed roots, skipping any that do not yet exist on disk.
     const allowedRoots: string[] = [];
@@ -521,7 +521,7 @@ async function handleApi(req: IncomingMessage, res: ServerResponse): Promise<voi
     }
 
     const cwd = process.cwd();
-    const home = join(homedir(), '.job-shit');
+    const home = join(homedir(), '.well-tailored');
 
     const allowedRoots: string[] = [];
     try {
@@ -744,7 +744,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   startWorkbenchServer(undefined, defaultHost)
     .then(({ port, host }) => {
       const displayHost = host === '127.0.0.1' ? 'localhost' : host;
-      console.log(`job-shit workbench listening on http://${displayHost}:${port}`);
+      console.log(`Well-Tailored workbench listening on http://${displayHost}:${port}`);
     })
     .catch((error) => {
       console.error(error instanceof Error ? error.message : String(error));

--- a/src/services/workspace-store.ts
+++ b/src/services/workspace-store.ts
@@ -3,8 +3,8 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { SavedWorkspace, SavedWorkspaceSummary, WorkspaceSnapshot } from '../types/index.js';
 
-const JOB_SHIT_HOME = join(homedir(), '.job-shit');
-const WORKSPACES_DIR = join(JOB_SHIT_HOME, 'workspaces');
+const TAILORED_HOME = join(homedir(), '.well-tailored');
+const WORKSPACES_DIR = join(TAILORED_HOME, 'workspaces');
 
 function ensureWorkspaceDir(): string {
   if (!existsSync(WORKSPACES_DIR)) {

--- a/src/tui/review.tsx
+++ b/src/tui/review.tsx
@@ -74,7 +74,7 @@ function visibleWindow<T>(items: T[], selectedIndex: number, radius = 5): T[] {
 }
 
 function openInEditor(initial: string, setRawMode: (isEnabled: boolean) => void): string {
-  const dir = mkdtempSync(join(tmpdir(), 'job-shit-review-'));
+  const dir = mkdtempSync(join(tmpdir(), 'well-tailored-review-'));
   const path = join(dir, 'section.md');
   const editor = process.env.EDITOR || 'vi';
 

--- a/src/workbench/index-v2.html
+++ b/src/workbench/index-v2.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>job-shit workbench v2</title>
+  <title>Tailored workbench</title>
   <link rel="icon" type="image/svg+xml" href='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"%3E%3Crect width="64" height="64" rx="14" fill="%23BE503C"/%3E%3Cpath d="M18 24h28v18H18z" fill="none" stroke="%23fff" stroke-width="4" stroke-linejoin="round"/%3E%3Cpath d="M26 24v-4a6 6 0 0 1 12 0v4" fill="none" stroke="%23fff" stroke-width="4" stroke-linecap="round"/%3E%3C/svg%3E'>
   <style>
     :root {
@@ -2026,7 +2026,7 @@
     <div class="top-bar__spacer"></div>
 
     <span id="docs-status" style="font-size:11px; opacity:0.7;">Loading docs...</span>
-    <span class="top-bar__storage" id="storage-indicator">&#x1F4BE; ~/.job-shit</span>
+    <span class="top-bar__storage" id="storage-indicator">&#x1F4BE; ~/.well-tailored</span>
   </header>
 
   <!-- ── APP LAYOUT ───────────────────────────────────────── -->

--- a/src/workbench/index.html
+++ b/src/workbench/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>job-shit workbench</title>
+  <title>Tailored workbench</title>
   <link rel="icon" type="image/svg+xml" href='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"%3E%3Crect width="64" height="64" rx="14" fill="%23BE503C"/%3E%3Cpath d="M18 24h28v18H18z" fill="none" stroke="%23fff" stroke-width="4" stroke-linejoin="round"/%3E%3Cpath d="M26 24v-4a6 6 0 0 1 12 0v4" fill="none" stroke="%23fff" stroke-width="4" stroke-linecap="round"/%3E%3C/svg%3E'>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1670,7 +1670,7 @@
           <button class="secondary async-action" id="loadWorkspaceBtn">Load Local Docs</button>
           <code id="cwdDisplay" style="font-size:11px;color:var(--muted);background:var(--surface-strong);padding:3px 8px;border-radius:4px;border:1px solid var(--line);max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></code>
         </div>
-        <p class="helper" style="margin-top:6px">Scans for <code>resume*.md</code>, <code>bio*.md</code>, and <code>cover-letter*.md</code> in the project directory (or <code>~/.job-shit/</code>). Files auto-reload when edited externally.</p>
+        <p class="helper" style="margin-top:6px">Scans for <code>resume*.md</code>, <code>bio*.md</code>, and <code>cover-letter*.md</code> in the project directory (or <code>~/.well-tailored/</code>). Files auto-reload when edited externally.</p>
       </div>
     </div>
 

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -61,7 +61,7 @@ function anthropicOk(text: string) {
 
 // Capture the original env so each test starts with a clean slate.
 const SAVED_ENV: Record<string, string | undefined> = {};
-const SAVED_JOB_SHIT_ENV: Record<string, string | undefined> = {};
+const SAVED_TAILORED_ENV: Record<string, string | undefined> = {};
 const PROVIDER_KEYS = [
   'GEMINI_API_KEY',
   'AZURE_OPENAI_ENDPOINT',
@@ -80,9 +80,9 @@ beforeEach(() => {
     delete process.env[k];
   });
   Object.keys(process.env)
-    .filter((key) => key.startsWith('JOB_SHIT_PROVIDER_') || key.startsWith('JOB_SHIT_'))
+    .filter((key) => key.startsWith('TAILORED_PROVIDER_') || key.startsWith('TAILORED_'))
     .forEach((key) => {
-      SAVED_JOB_SHIT_ENV[key] = process.env[key];
+      SAVED_TAILORED_ENV[key] = process.env[key];
       delete process.env[key];
     });
   mockChatCreate.mockReset();
@@ -97,13 +97,13 @@ afterEach(() => {
       process.env[k] = SAVED_ENV[k];
     }
   });
-  Object.keys(SAVED_JOB_SHIT_ENV).forEach((key) => {
-    if (SAVED_JOB_SHIT_ENV[key] === undefined) {
+  Object.keys(SAVED_TAILORED_ENV).forEach((key) => {
+    if (SAVED_TAILORED_ENV[key] === undefined) {
       delete process.env[key];
     } else {
-      process.env[key] = SAVED_JOB_SHIT_ENV[key];
+      process.env[key] = SAVED_TAILORED_ENV[key];
     }
-    delete SAVED_JOB_SHIT_ENV[key];
+    delete SAVED_TAILORED_ENV[key];
   });
   vi.useRealTimers();
 });
@@ -212,12 +212,12 @@ describe('provider selection', () => {
   });
 
   it('supports named OpenAI-compatible profiles such as Groq', async () => {
-    process.env.JOB_SHIT_PROVIDER_PROFILES = 'groq';
-    process.env.JOB_SHIT_PROVIDER_GROQ_KIND = 'openai';
-    process.env.JOB_SHIT_PROVIDER_GROQ_LABEL = 'Groq';
-    process.env.JOB_SHIT_PROVIDER_GROQ_API_KEY = 'groq-key';
-    process.env.JOB_SHIT_PROVIDER_GROQ_BASE_URL = 'https://api.groq.com/openai/v1';
-    process.env.JOB_SHIT_PROVIDER_GROQ_DEFAULT_MODEL = 'llama-3.3-70b-versatile';
+    process.env.TAILORED_PROVIDER_PROFILES = 'groq';
+    process.env.TAILORED_PROVIDER_GROQ_KIND = 'openai';
+    process.env.TAILORED_PROVIDER_GROQ_LABEL = 'Groq';
+    process.env.TAILORED_PROVIDER_GROQ_API_KEY = 'groq-key';
+    process.env.TAILORED_PROVIDER_GROQ_BASE_URL = 'https://api.groq.com/openai/v1';
+    process.env.TAILORED_PROVIDER_GROQ_DEFAULT_MODEL = 'llama-3.3-70b-versatile';
     mockChatCreate.mockResolvedValueOnce(openaiOk('groq response'));
 
     const result = await complete('auto', 'sys', 'user', false, { provider: 'groq' });

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'os';
 import { findFile } from '../src/lib/files.js';
 
 function tmpDir(): string {
-  const dir = join(tmpdir(), `job-shit-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const dir = join(tmpdir(), `well-tailored-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(dir, { recursive: true });
   return dir;
 }


### PR DESCRIPTION
## Summary
- Renamed all references from `job-shit` to `well-tailored` across source code, config, docs, and tests (env vars, CLI names, file paths, promo materials)
- Added `BRAND.md` with the full style guide: colors, typography, layout principles, button styles, card/surface specs, input styling, and logo direction
- Updated `package.json` name to `well-tailored`

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 151 tests pass
- [ ] Verify no remaining `job-shit` / `JOB_SHIT` references in codebase
- [ ] Confirm `BRAND.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Product rebranding: CLI command is now `tailored`; configuration environment variables updated with `TAILORED_` prefix; user data directory changed to `~/.well-tailored`; temporary file naming updated accordingly.

* **Documentation**
  * Updated all guides, README, brand standards, and visual assets to reflect new product identity and command references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->