### PR TITLE
fix(jobs): sort 'Added' by Huntr listPosition for non-wishlist stages

### DIFF
--- a/tests/web-job-sort.test.ts
+++ b/tests/web-job-sort.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { sortJobs } from '../web/src/features/jobs/sort.js';
+import type { Job } from '../web/src/types.js';
+
+function job(overrides: Partial<Job>): Job {
+  return {
+    id: overrides.id ?? 'x',
+    company: overrides.company ?? '',
+    title: overrides.title ?? '',
+    jd: '',
+    stage: overrides.stage ?? 'Applied',
+    source: 'huntr',
+    dbJobId: null,
+    huntrId: overrides.id ?? 'x',
+    listAddedAt: overrides.listAddedAt ?? null,
+    listPosition: overrides.listPosition ?? null,
+    boardId: null,
+    status: 'loaded',
+    checked: false,
+    scoresStale: false,
+    result: null,
+    error: null,
+    _editorData: null,
+  };
+}
+
+describe('sortJobs — Added date', () => {
+  it('uses listPosition (Huntr order) as the primary signal, ascending listPosition for desc', () => {
+    // Huntr convention: listPosition 0 = top of list = most recently added.
+    // So "Added desc" should surface listPosition 0 first.
+    const jobs = [
+      job({ id: 'c', listPosition: 2, listAddedAt: '2026-01-01T00:00:00Z' }),
+      job({ id: 'a', listPosition: 0, listAddedAt: '2025-01-01T00:00:00Z' }),
+      job({ id: 'b', listPosition: 1, listAddedAt: '2024-01-01T00:00:00Z' }),
+    ];
+    expect(sortJobs(jobs, 'listAddedAt', 'desc').map((j) => j.id)).toEqual(['a', 'b', 'c']);
+    expect(sortJobs(jobs, 'listAddedAt', 'asc').map((j) => j.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('falls back to timestamp when listPosition is unavailable', () => {
+    const jobs = [
+      job({ id: 'old', listAddedAt: '2025-01-01T00:00:00Z' }),
+      job({ id: 'new', listAddedAt: '2026-01-01T00:00:00Z' }),
+    ];
+    expect(sortJobs(jobs, 'listAddedAt', 'desc').map((j) => j.id)).toEqual(['new', 'old']);
+  });
+
+  it('sends jobs missing both listPosition and timestamp to the bottom', () => {
+    const jobs = [
+      job({ id: 'missing' }),
+      job({ id: 'ranked', listPosition: 3 }),
+    ];
+    expect(sortJobs(jobs, 'listAddedAt', 'desc').map((j) => j.id)).toEqual(['ranked', 'missing']);
+    expect(sortJobs(jobs, 'listAddedAt', 'asc').map((j) => j.id)).toEqual(['ranked', 'missing']);
+  });
+});

--- a/web/src/features/jobs/JobList.tsx
+++ b/web/src/features/jobs/JobList.tsx
@@ -18,6 +18,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/components/ui/utils';
 import { formatStageLabel, getDisplayStage, getStageBadgeClass, matchesJobFilter } from './stages';
+import { sortJobs, type SortField, type SortDir } from './sort';
 
 const STAGE_ORDER = [
   'wishlist', 'applied', 'interview', 'offer', 'rejected', 'timeout', 'old wishlist', 'manual', 'other',
@@ -46,57 +47,6 @@ function getScorecardWarning(job: Job): 'error' | 'warn' | null {
   if (scorecard.verdict === 'do_not_submit' || scorecard.blockingIssues.length > 0) return 'error';
   if (scorecard.verdict === 'needs_revision') return 'warn';
   return null;
-}
-
-type SortField = 'company' | 'title' | 'status' | 'listAddedAt';
-type SortDir = 'asc' | 'desc';
-
-const STATUS_ORDER: Record<Job['status'], number> = {
-  loaded: 0, tailored: 1, reviewed: 2, tailoring: 3, error: 4,
-};
-
-function sortJobs(jobs: Job[], field: SortField | null, dir: SortDir): Job[] {
-  if (!field) return jobs;
-  return [...jobs].sort((a, b) => {
-    let cmp: number;
-    if (field === 'status') {
-      cmp = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
-    } else if (field === 'listAddedAt') {
-      return compareByAddedDate(a, b, dir);
-    } else {
-      cmp = (a[field] ?? '').localeCompare(b[field] ?? '');
-    }
-    return dir === 'asc' ? cmp : -cmp;
-  });
-}
-
-function getAddedTime(job: Job): number | null {
-  const time = Date.parse(job.listAddedAt ?? '');
-  return Number.isFinite(time) ? time : null;
-}
-
-function compareByAddedDate(a: Job, b: Job, dir: SortDir): number {
-  const aTime = getAddedTime(a);
-  const bTime = getAddedTime(b);
-
-  // Jobs without Huntr timestamps should not jump to the top in either direction.
-  if (aTime === null && bTime === null) return compareByStableFallback(a, b);
-  if (aTime === null) return 1;
-  if (bTime === null) return -1;
-
-  const dateCmp = dir === 'asc' ? aTime - bTime : bTime - aTime;
-  if (dateCmp !== 0) return dateCmp;
-
-  const positionCmp = (a.listPosition ?? Number.MAX_SAFE_INTEGER) - (b.listPosition ?? Number.MAX_SAFE_INTEGER);
-  if (positionCmp !== 0) return positionCmp;
-
-  return compareByStableFallback(a, b);
-}
-
-function compareByStableFallback(a: Job, b: Job): number {
-  const companyCmp = (a.company ?? '').localeCompare(b.company ?? '');
-  if (companyCmp !== 0) return companyCmp;
-  return (a.title ?? '').localeCompare(b.title ?? '');
 }
 
 function formatAddedDate(value: string | null | undefined): string | null {

--- a/web/src/features/jobs/sort.ts
+++ b/web/src/features/jobs/sort.ts
@@ -1,0 +1,64 @@
+import type { Job } from '../../types';
+
+export type SortField = 'company' | 'title' | 'status' | 'listAddedAt';
+export type SortDir = 'asc' | 'desc';
+
+const STATUS_ORDER: Record<Job['status'], number> = {
+  loaded: 0, tailored: 1, reviewed: 2, tailoring: 3, error: 4,
+};
+
+function getAddedTime(job: Job): number | null {
+  const time = Date.parse(job.listAddedAt ?? '');
+  return Number.isFinite(time) ? time : null;
+}
+
+function compareByStableFallback(a: Job, b: Job): number {
+  const companyCmp = (a.company ?? '').localeCompare(b.company ?? '');
+  if (companyCmp !== 0) return companyCmp;
+  return (a.title ?? '').localeCompare(b.title ?? '');
+}
+
+function compareByAddedDate(a: Job, b: Job, dir: SortDir): number {
+  // Huntr's per-list order (listPosition) is the authoritative "added to this list"
+  // signal across stages. `lastMovedAt` only reflects the last stage transition, so
+  // for non-wishlist stages it doesn't mean "added to this list" and can be missing
+  // entirely. listPosition 0 is the top of Huntr's list (most recently added), so
+  // "Added desc" maps to ascending listPosition.
+  const aPos = a.listPosition ?? null;
+  const bPos = b.listPosition ?? null;
+  if (aPos !== null && bPos !== null) {
+    if (aPos !== bPos) {
+      const posCmp = aPos - bPos;
+      return dir === 'desc' ? posCmp : -posCmp;
+    }
+  } else if (aPos !== null) {
+    return -1;
+  } else if (bPos !== null) {
+    return 1;
+  }
+
+  const aTime = getAddedTime(a);
+  const bTime = getAddedTime(b);
+  if (aTime === null && bTime === null) return compareByStableFallback(a, b);
+  if (aTime === null) return 1;
+  if (bTime === null) return -1;
+  const dateCmp = dir === 'asc' ? aTime - bTime : bTime - aTime;
+  if (dateCmp !== 0) return dateCmp;
+
+  return compareByStableFallback(a, b);
+}
+
+export function sortJobs(jobs: Job[], field: SortField | null, dir: SortDir): Job[] {
+  if (!field) return jobs;
+  return [...jobs].sort((a, b) => {
+    let cmp: number;
+    if (field === 'status') {
+      cmp = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
+    } else if (field === 'listAddedAt') {
+      return compareByAddedDate(a, b, dir);
+    } else {
+      cmp = (a[field] ?? '').localeCompare(b[field] ?? '');
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+}


### PR DESCRIPTION
## Summary
- `getListAddedAt` returns `lastMovedAt ?? createdAt`, which only approximates "added to this list" for Wishlist. In later stages `lastMovedAt` is the stage-transition timestamp (often null), so sort-by-Added fell apart.
- Switch sort to prefer Huntr's per-list `listPosition` (0 = top of Huntr's list = most recently added). Timestamp stays as fallback for jobs without a list position.
- Extracted `sortJobs` into its own module so it's testable without pulling in the React view.

Closes #108

## Test plan
- [x] `npx vitest run tests/web-job-sort.test.ts` — new unit coverage for listPosition primary + timestamp fallback + missing-signal behaviour
- [x] `npm run typecheck`
- [x] `cd web && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized job sorting logic into a dedicated module for improved code maintainability. No changes to sorting behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->