### PR TITLE
fix(workbench): persist tailor queue across refresh via backend tasks

### DIFF
--- a/tests/web-state.test.ts
+++ b/tests/web-state.test.ts
@@ -208,4 +208,76 @@ describe('web state reducer', () => {
     expect(next.jobs[0]?.stage).toBe('interview');
     expect(next.activeJobId).toBe('huntr-1');
   });
+
+  describe('SYNC_TAILOR_FROM_TASKS', () => {
+    it('rehydrates tailor queue and running job from backend task state', () => {
+      const state = makeState({ tailorQueue: [], tailorQueueTotal: 0, tailorRunning: null });
+      const next = reducer(state, {
+        type: 'SYNC_TAILOR_FROM_TASKS',
+        pendingIds: ['job-2', 'job-3', 'job-4'],
+        runningId: 'job-1',
+        runningStartedAt: 1_700_000_000_000,
+      });
+
+      expect(next.tailorQueue).toEqual(['job-2', 'job-3', 'job-4']);
+      expect(next.tailorRunning).toBe('job-1');
+      expect(next.tailorRunningStartedAt).toBe(1_700_000_000_000);
+      // Total includes the currently-running job so progress reflects all in-flight work.
+      expect(next.tailorQueueTotal).toBe(4);
+    });
+
+    it('preserves an existing startedAt when the running job is unchanged', () => {
+      const state = makeState({
+        tailorQueue: ['job-2'],
+        tailorQueueTotal: 2,
+        tailorRunning: 'job-1',
+        tailorRunningStartedAt: 1_699_999_999_000,
+      });
+      const next = reducer(state, {
+        type: 'SYNC_TAILOR_FROM_TASKS',
+        pendingIds: ['job-2'],
+        runningId: 'job-1',
+        runningStartedAt: 1_700_000_000_000,
+      });
+
+      expect(next.tailorRunningStartedAt).toBe(1_699_999_999_000);
+    });
+
+    it('clears state when no tailor tasks remain', () => {
+      const state = makeState({
+        tailorQueue: ['job-2'],
+        tailorQueueTotal: 3,
+        tailorRunning: 'job-1',
+        tailorRunningStartedAt: 1_700_000_000_000,
+      });
+      const next = reducer(state, {
+        type: 'SYNC_TAILOR_FROM_TASKS',
+        pendingIds: [],
+        runningId: null,
+      });
+
+      expect(next.tailorQueue).toEqual([]);
+      expect(next.tailorQueueTotal).toBe(0);
+      expect(next.tailorRunning).toBeNull();
+      expect(next.tailorRunningStartedAt).toBe(0);
+    });
+
+    it('keeps prior total when it exceeds current in-flight (so progress bar reflects overall batch)', () => {
+      const state = makeState({
+        tailorQueue: ['job-2', 'job-3'],
+        tailorQueueTotal: 5,
+        tailorRunning: 'job-1',
+        tailorRunningStartedAt: 1_700_000_000_000,
+      });
+      const next = reducer(state, {
+        type: 'SYNC_TAILOR_FROM_TASKS',
+        pendingIds: ['job-3'],
+        runningId: 'job-2',
+      });
+
+      expect(next.tailorQueueTotal).toBe(5);
+      expect(next.tailorQueue).toEqual(['job-3']);
+      expect(next.tailorRunning).toBe('job-2');
+    });
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -103,28 +103,30 @@ function AppShell() {
 
   const handleActiveTask = useCallback((task: TaskRecord) => {
     if (task.type !== 'tailor') return;
-    if (state.tailorRunning) return;
     try {
       const input = getTailorTaskMetadata(task);
       const frontendJobId = input.frontendJobId;
       const jobLabel = `${input.company ?? 'selected company'}${input.jobTitle ? ` — ${input.jobTitle}` : ''}`;
-      const startedAt = Date.parse(task.updatedAt) || Date.parse(task.createdAt) || Date.now();
-      dispatch({ type: 'SET_TAILOR_RUNNING', id: frontendJobId, startedAt });
+      // Mark the job as tailoring so the list shows the spinner. tailorRunning and
+      // the pending queue itself are owned by the SYNC_TAILOR_FROM_TASKS action fired
+      // at the end of each poll — doing it here would flicker for pending tasks.
       dispatch({
         type: 'UPDATE_JOB',
         id: frontendJobId,
         patch: { status: 'tailoring', dbJobId: task.jobId },
       });
-      dispatch({
-        type: 'SET_RUN_FEEDBACK',
-        feedback: { text: `Tailoring ${jobLabel}…`, type: 'working' },
-      });
-      dispatch({
-        type: 'ADD_ACTIVITY_LOG',
-        message: `Resumed tracking in-flight tailoring for ${jobLabel}.`,
-        logType: 'working',
-      });
-      console.info('[workbench] Resumed tracking active tailoring task', {
+      if (task.status === 'running' && !state.tailorRunning) {
+        dispatch({
+          type: 'SET_RUN_FEEDBACK',
+          feedback: { text: `Tailoring ${jobLabel}…`, type: 'working' },
+        });
+        dispatch({
+          type: 'ADD_ACTIVITY_LOG',
+          message: `Resumed tracking in-flight tailoring for ${jobLabel}.`,
+          logType: 'working',
+        });
+      }
+      console.info('[workbench] Observed active tailoring task', {
         taskId: task.id,
         frontendJobId,
         status: task.status,
@@ -134,11 +136,24 @@ function AppShell() {
     }
   }, [dispatch, state.tailorRunning]);
 
+  const handleTailorSync = useCallback(
+    (snapshot: { pendingIds: string[]; runningId: string | null; runningStartedAt: number }) => {
+      dispatch({
+        type: 'SYNC_TAILOR_FROM_TASKS',
+        pendingIds: snapshot.pendingIds,
+        runningId: snapshot.runningId,
+        runningStartedAt: snapshot.runningStartedAt || undefined,
+      });
+    },
+    [dispatch],
+  );
+
   useTaskPolling({
     workspaceId: state.activeWorkspaceId,
     onTaskCompleted: handleTaskCompleted,
     onTaskFailed: handleTaskFailed,
     onActiveTask: handleActiveTask,
+    onTailorSync: handleTailorSync,
   });
 
   const [isDesktop, setIsDesktop] = useState(() => (

--- a/web/src/hooks/useTailorQueue.ts
+++ b/web/src/hooks/useTailorQueue.ts
@@ -12,7 +12,9 @@ export function useTailorQueue() {
   useEffect(() => {
     if (processingRef.current) return;
     if (state.tailorQueue.length === 0) return;
-    if (state.tailorRunning !== null) return;
+    // Intentionally no gate on tailorRunning: every selected job should land as a
+    // pending DB task as fast as possible so pending tasks survive a page refresh.
+    // The worker still processes them one at a time via TaskRepo.claimNext.
 
     const jobId = state.tailorQueue[0];
     const job = state.jobs.find((j) => j.id === jobId);
@@ -26,7 +28,9 @@ export function useTailorQueue() {
 
     async function processJob() {
       dispatch({ type: 'SET_TAILOR_SUMMARY', summary: null });
-      dispatch({ type: 'SET_TAILOR_RUNNING', id: jobId });
+      // Don't optimistically set tailorRunning here — with the serial gate removed
+      // we might enqueue several jobs in quick succession and only one is actually
+      // running at the worker. The task poller sets tailorRunning from real state.
       dispatch({ type: 'UPDATE_JOB', id: jobId, patch: { status: 'tailoring', error: null } });
       dispatch({
         type: 'SET_RUN_FEEDBACK',

--- a/web/src/hooks/useTaskPolling.ts
+++ b/web/src/hooks/useTaskPolling.ts
@@ -1,15 +1,23 @@
 import { useEffect, useRef } from 'react';
 import { listTasks, type TaskRecord } from '../api/client.js';
+import { getTailorTaskMetadata } from '../lib/tasks.js';
+
+interface TailorSyncSnapshot {
+  pendingIds: string[];
+  runningId: string | null;
+  runningStartedAt: number;
+}
 
 interface UseTaskPollingOptions {
   workspaceId: string | null;
   onTaskCompleted: (task: TaskRecord) => void;
   onTaskFailed: (task: TaskRecord) => void;
   onActiveTask?: (task: TaskRecord) => void;
+  onTailorSync?: (snapshot: TailorSyncSnapshot) => void;
   intervalMs?: number;
 }
 
-export function useTaskPolling({ workspaceId, onTaskCompleted, onTaskFailed, onActiveTask, intervalMs = 2000 }: UseTaskPollingOptions) {
+export function useTaskPolling({ workspaceId, onTaskCompleted, onTaskFailed, onActiveTask, onTailorSync, intervalMs = 2000 }: UseTaskPollingOptions) {
   const knownTasksRef = useRef<Map<string, TaskRecord>>(new Map());
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -70,6 +78,22 @@ export function useTaskPolling({ workspaceId, onTaskCompleted, onTaskFailed, onA
           known.set(task.id, task);
         }
 
+        if (onTailorSync) {
+          const tailorTasks = tasks.filter((t) => t.type === 'tailor');
+          const pendingIds: string[] = [];
+          let runningId: string | null = null;
+          let runningStartedAt = 0;
+          for (const task of tailorTasks) {
+            if (task.status === 'pending') {
+              pendingIds.push(getTailorTaskMetadata(task).frontendJobId);
+            } else if (task.status === 'running' && runningId == null) {
+              runningId = getTailorTaskMetadata(task).frontendJobId;
+              runningStartedAt = Date.parse(task.updatedAt) || Date.parse(task.createdAt) || Date.now();
+            }
+          }
+          onTailorSync({ pendingIds, runningId, runningStartedAt });
+        }
+
         const hasActive = tasks.some(t => t.status === 'pending' || t.status === 'running');
         if (hasActive && !cancelled) {
           schedulePoll(intervalMs);
@@ -91,5 +115,5 @@ export function useTaskPolling({ workspaceId, onTaskCompleted, onTaskFailed, onA
         timeoutRef.current = null;
       }
     };
-  }, [workspaceId, onTaskCompleted, onTaskFailed, onActiveTask, intervalMs]);
+  }, [workspaceId, onTaskCompleted, onTaskFailed, onActiveTask, onTailorSync, intervalMs]);
 }

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -91,6 +91,7 @@ export type Action =
   | { type: 'SET_JOB_DOCUMENT_STATE'; id: string; doc: ActiveDoc; editorData: EditorData; markdown: string }
   | { type: 'SET_TAILOR_QUEUE'; queue: string[]; total?: number }
   | { type: 'SET_TAILOR_RUNNING'; id: string | null; startedAt?: number }
+  | { type: 'SYNC_TAILOR_FROM_TASKS'; pendingIds: string[]; runningId: string | null; runningStartedAt?: number }
   | { type: 'SET_TAILOR_SUMMARY'; summary: { tailored: number; failed: number } | null }
   | { type: 'SET_JOB_SCORES_STALE'; id: string; stale: boolean }
   | { type: 'SET_REGRADE_QUEUE'; queue: string[]; total?: number }
@@ -335,6 +336,29 @@ export function reducer(state: WorkspaceState, action: Action): WorkspaceState {
         tailorRunningStartedAt:
           action.id == null ? 0 : action.startedAt ?? Date.now(),
       };
+
+    case 'SYNC_TAILOR_FROM_TASKS': {
+      // Reconcile tailor queue/running from backend task state. This is what makes
+      // the tailoring progress bar survive a page refresh: pending tasks in SQLite
+      // repopulate the queue even though the in-memory queue was wiped.
+      const pendingSet = new Set(action.pendingIds);
+      const runningId = action.runningId;
+      const inFlight = runningId != null ? pendingSet.size + 1 : pendingSet.size;
+      const total = Math.max(state.tailorQueueTotal, inFlight);
+      const runningStartedAt =
+        runningId == null
+          ? 0
+          : state.tailorRunning === runningId && state.tailorRunningStartedAt
+          ? state.tailorRunningStartedAt
+          : action.runningStartedAt ?? Date.now();
+      return {
+        ...state,
+        tailorQueue: action.pendingIds,
+        tailorQueueTotal: inFlight === 0 ? 0 : total,
+        tailorRunning: runningId,
+        tailorRunningStartedAt: runningStartedAt,
+      };
+    }
 
     case 'SET_TAILOR_SUMMARY':
       return { ...state, tailorLastSummary: action.summary };


### PR DESCRIPTION
## Summary
The frontend tailor queue lived only in React state and was gated so only the currently-running job had a DB task row. On refresh, `tailorQueue` reset to `[]` (see `workspacePersistence.ts:431`) and the other selected jobs silently vanished — only the one in-flight task survived.

This PR makes the backend `tasks` table the source of truth:
- `useTailorQueue` no longer waits for the worker to finish before creating the next task. All selected jobs land as `pending` DB tasks immediately. The worker still processes them one at a time via `TaskRepo.claimNext`.
- `useTaskPolling` now emits a tailor-sync snapshot (pending frontend ids + running id). A new `SYNC_TAILOR_FROM_TASKS` reducer action reconciles the UI queue and running job from that snapshot — so a refresh repopulates the queue from SQLite.
- `handleActiveTask` stops eagerly flipping `tailorRunning` for each observed pending task (it was racing itself when multiple pendings arrived in one poll); the sync action owns that state now.

Closes #107

## Test plan
- [x] `npx vitest run tests/web-state.test.ts` — new reducer coverage: rehydrate queue+running, preserve startedAt, clear on drain, keep max-total across a batch
- [x] `npm run typecheck`
- [x] `cd web && npx tsc --noEmit`
- [ ] Manual: select 5 Huntr jobs → Tailor → refresh mid-batch → queue and running indicator survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)