### PR TITLE
[codex] fix resume export background variable

### DIFF
--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -389,7 +389,8 @@ function buildThemeCss(theme?: Partial<ResumeTheme>): string {
     link: safeColor(merged.link, DEFAULT_RESUME_THEME.link),
   };
   return `
-html, body, .resume { background: ${resolved.background}; }
+:root { --resume-background: ${resolved.background}; }
+html, body, .resume { background: var(--resume-background, ${DEFAULT_RESUME_THEME.background}); }
 body, li, p, ul { color: ${resolved.body}; }
 h1, h2.section { color: ${resolved.accent}; }
 h2.role, .job-company { color: ${resolved.subheading}; }

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -126,7 +126,18 @@ jane@example.com | mattmcknight.com
   it('uses the lighter default resume background theme', () => {
     const html = renderResumeHtml(SAMPLE);
     expect(html).toContain('background: var(--resume-background, #E5F2FF);');
-    expect(html).toContain('html, body, .resume { background: #E5F2FF; }');
+    expect(html).toContain(':root { --resume-background: #E5F2FF; }');
+    expect(html).toContain('html, body, .resume { background: var(--resume-background, #E5F2FF); }');
+  });
+
+  it('sets the resume background variable so print and PDF styles use the chosen theme color', () => {
+    const html = renderResumeHtml(SAMPLE, undefined, false, {
+      background: '#F6F0E4',
+    });
+
+    expect(html).toContain(':root { --resume-background: #F6F0E4; }');
+    expect(html).toContain('@page {\n    margin: 1cm;\n    size: letter portrait;\n    background: var(--resume-background, #E5F2FF);');
+    expect(html).toContain('html, body, .resume { background: var(--resume-background, #E5F2FF); }');
   });
 
   it('keeps compact date rows flush with the job heading', () => {


### PR DESCRIPTION
## Summary
This fixes a resume export styling bug where browser print preview and PDF output could use the wrong background color.

## Problem
The resume template CSS already relies on `var(--resume-background, ...)` for the page, resume container, and print styles. But the final theme CSS injected by `renderResumeHtml()` ended with a hard-coded `html, body, .resume { background: ... }` rule and never defined `--resume-background`.

That meant the normal page view could look right while print-focused styles such as `@page`, `html`, and `body` still fell back to the default background color. In practice, custom resume backgrounds could drift back to the default light blue when exported or printed.

## Fix
The renderer now sets `:root { --resume-background: ... }` in the injected theme CSS and uses `background: var(--resume-background, #E5F2FF)` for the final `html, body, .resume` override.

This makes the inline theme block and the shared template CSS read from the same source of truth, so HTML rendering, print preview, and PDF export stay aligned.

## Validation
I verified the change with:
- `npx vitest run tests/render.test.ts`
- `npm run typecheck`

I also added a regression test that covers a custom background color to make sure the print/PDF path keeps honoring the selected theme.

Closes #111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved theme background handling by implementing CSS custom properties. The background color system now uses reusable CSS variables with fallback values, enabling enhanced customization flexibility and ensuring consistent background styling across different rendering contexts, including screen display and PDF/print output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->