### PR TITLE
fix(workbench): resume export bg, tailor queue progress, source status labels

### DIFF
--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -389,7 +389,8 @@ function buildThemeCss(theme?: Partial<ResumeTheme>): string {
     link: safeColor(merged.link, DEFAULT_RESUME_THEME.link),
   };
   return `
-html, body, .resume { background: ${resolved.background}; }
+:root { --resume-background: ${resolved.background}; }
+html, body, .resume { background: var(--resume-background, ${DEFAULT_RESUME_THEME.background}); }
 body, li, p, ul { color: ${resolved.body}; }
 h1, h2.section { color: ${resolved.accent}; }
 h2.role, .job-company { color: ${resolved.subheading}; }

--- a/tests/render.test.ts
+++ b/tests/render.test.ts
@@ -126,7 +126,18 @@ jane@example.com | mattmcknight.com
   it('uses the lighter default resume background theme', () => {
     const html = renderResumeHtml(SAMPLE);
     expect(html).toContain('background: var(--resume-background, #E5F2FF);');
-    expect(html).toContain('html, body, .resume { background: #E5F2FF; }');
+    expect(html).toContain(':root { --resume-background: #E5F2FF; }');
+    expect(html).toContain('html, body, .resume { background: var(--resume-background, #E5F2FF); }');
+  });
+
+  it('sets the resume background variable so print and PDF styles use the chosen theme color', () => {
+    const html = renderResumeHtml(SAMPLE, undefined, false, {
+      background: '#F6F0E4',
+    });
+
+    expect(html).toContain(':root { --resume-background: #F6F0E4; }');
+    expect(html).toContain('@page {\n    margin: 1cm;\n    size: letter portrait;\n    background: var(--resume-background, #E5F2FF);');
+    expect(html).toContain('html, body, .resume { background: var(--resume-background, #E5F2FF); }');
   });
 
   it('keeps compact date rows flush with the job heading', () => {

--- a/tests/web-queue.test.ts
+++ b/tests/web-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { appendUniqueJobIdsToQueue } from '../web/src/lib/queues.js';
+import { appendUniqueJobIdsToQueue, getQueueProgress } from '../web/src/lib/queues.js';
 
 describe('appendUniqueJobIdsToQueue', () => {
   it('starts a fresh queue with the incoming ids', () => {
@@ -30,5 +30,49 @@ describe('appendUniqueJobIdsToQueue', () => {
       total: 3,
       added: ['job-3'],
     });
+  });
+});
+
+describe('getQueueProgress', () => {
+  it('treats tailoring queues as excluding the running job', () => {
+    expect(getQueueProgress({
+      queue: ['job-2', 'job-3', 'job-4'],
+      total: 4,
+      hasRunning: true,
+      queueIncludesRunning: false,
+    })).toEqual({
+      resolvedTotal: 4,
+      currentPosition: 1,
+      queuedAfterCurrent: 3,
+      progress: 25,
+    });
+  });
+
+  it('preserves the final position while the last tailoring job is still running', () => {
+    expect(getQueueProgress({
+      queue: [],
+      total: 4,
+      hasRunning: true,
+      queueIncludesRunning: false,
+    })).toEqual({
+      resolvedTotal: 4,
+      currentPosition: 4,
+      queuedAfterCurrent: 0,
+      progress: 100,
+    });
+  });
+
+  it('still supports queues that include the running job', () => {
+    const result = getQueueProgress({
+      queue: ['job-1', 'job-2', 'job-3'],
+      total: 3,
+      hasRunning: true,
+      queueIncludesRunning: true,
+    });
+
+    expect(result.resolvedTotal).toBe(3);
+    expect(result.currentPosition).toBe(1);
+    expect(result.queuedAfterCurrent).toBe(2);
+    expect(result.progress).toBeCloseTo(33.33333333333333, 10);
   });
 });

--- a/tests/web-source-status.test.ts
+++ b/tests/web-source-status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getSourceStatusLabel } from '../web/src/features/sources/sourceStatus.js';
+
+describe('getSourceStatusLabel', () => {
+  it('shows the filesystem path when a local source file is loaded', () => {
+    expect(getSourceStatusLabel({
+      filePath: '/Users/matt/resume.md',
+      value: 'Resume content',
+      hasSavedWorkspace: true,
+    })).toBe('Loaded from /Users/matt/resume.md');
+  });
+
+  it('shows that source text is saved when it belongs to a saved workspace', () => {
+    expect(getSourceStatusLabel({
+      value: 'Saved source content',
+      hasSavedWorkspace: true,
+    })).toBe('Saved in workspace');
+  });
+
+  it('shows that source text is still unsaved when no workspace exists yet', () => {
+    expect(getSourceStatusLabel({
+      value: 'Scratch source content',
+      hasSavedWorkspace: false,
+    })).toBe('Unsaved in editor');
+  });
+
+  it('shows not loaded when the source is empty', () => {
+    expect(getSourceStatusLabel({
+      value: '',
+      hasSavedWorkspace: false,
+    })).toBe('Not loaded');
+  });
+});

--- a/tests/web-tailor-queue-state.test.ts
+++ b/tests/web-tailor-queue-state.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { initialState, reducer } from '../web/src/state.js';
+
+describe('tailor queue state', () => {
+  it('preserves tailoring totals while the last queued job is still running', () => {
+    const state = {
+      ...initialState,
+      tailorQueue: ['job-1'],
+      tailorQueueTotal: 4,
+      tailorRunning: 'job-4',
+    };
+
+    const runningLastJob = reducer(state, {
+      type: 'SET_TAILOR_QUEUE',
+      queue: [],
+    });
+    const completed = reducer(runningLastJob, {
+      type: 'SET_TAILOR_RUNNING',
+      id: null,
+    });
+
+    expect(runningLastJob.tailorQueueTotal).toBe(4);
+    expect(completed.tailorQueueTotal).toBe(0);
+  });
+});

--- a/web/src/features/sources/SourcesPanel.tsx
+++ b/web/src/features/sources/SourcesPanel.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Upload } from 'lucide-react';
 import { useWorkspace } from '../../context';
 import type { Action } from '../../state';
+import { getSourceStatusLabel } from './sourceStatus.js';
 
 type SourceField = 'sourceResume' | 'sourceBio' | 'sourceCoverLetter' | 'sourceSupplemental';
 
@@ -22,11 +23,13 @@ function SourceItemRow({
   item,
   value,
   filePath,
+  hasSavedWorkspace,
   dispatch,
 }: {
   item: SourceItem;
   value: string;
   filePath: string | undefined;
+  hasSavedWorkspace: boolean;
   dispatch: React.Dispatch<Action>;
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -52,11 +55,11 @@ function SourceItemRow({
     dispatch({ type: 'SET_SOURCE', field: item.field, value: e.target.value });
   }
 
-  const statusText = filePath
-    ? `Loaded from ${filePath}`
-    : value
-    ? 'Loaded (edited)'
-    : 'Not loaded';
+  const statusText = getSourceStatusLabel({
+    filePath,
+    value,
+    hasSavedWorkspace,
+  });
 
   return (
     <div className="border-b border-border" style={{ padding: '10px 8px' }}>
@@ -82,13 +85,9 @@ function SourceItemRow({
         />
       </div>
 
-      {/* File path */}
-      <div className="font-mono text-[11px] text-muted-foreground mb-1 break-all leading-snug">
-        {filePath || (value ? '(edited in place)' : 'Not loaded')}
+      <div className="font-mono text-[11px] text-muted-foreground mb-2 break-all leading-snug">
+        {statusText}
       </div>
-
-      {/* Status */}
-      <div className="text-[11px] text-muted-foreground mb-2">{statusText}</div>
 
       {/* Textarea */}
       <textarea
@@ -105,6 +104,7 @@ function SourceItemRow({
 
 export function SourcesPanel() {
   const { state, dispatch } = useWorkspace();
+  const hasSavedWorkspace = Boolean(state.activeWorkspaceId);
 
   return (
     <div className="flex flex-col overflow-y-auto flex-1 min-h-0">
@@ -114,6 +114,7 @@ export function SourcesPanel() {
           item={item}
           value={state[item.field]}
           filePath={state.sourcePaths[item.pathKey]}
+          hasSavedWorkspace={hasSavedWorkspace}
           dispatch={dispatch}
         />
       ))}

--- a/web/src/features/sources/sourceStatus.ts
+++ b/web/src/features/sources/sourceStatus.ts
@@ -1,0 +1,19 @@
+export function getSourceStatusLabel({
+  filePath,
+  value,
+  hasSavedWorkspace,
+}: {
+  filePath?: string;
+  value: string;
+  hasSavedWorkspace: boolean;
+}): string {
+  if (filePath) {
+    return `Loaded from ${filePath}`;
+  }
+
+  if (!value) {
+    return 'Not loaded';
+  }
+
+  return hasSavedWorkspace ? 'Saved in workspace' : 'Unsaved in editor';
+}

--- a/web/src/features/workspace/JobQueueStatus.tsx
+++ b/web/src/features/workspace/JobQueueStatus.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Progress } from '@/components/ui/progress';
 import { useWorkspace } from '@/context';
 import { formatElapsed } from '@/lib/markdown';
+import { getQueueProgress } from '@/lib/queues';
 
 interface JobQueueStatusProps {
   runningId: string | null;
@@ -12,6 +13,7 @@ interface JobQueueStatusProps {
   detail?: string;
   progressClassName: string;
   containerClassName: string;
+  queueIncludesRunning?: boolean;
 }
 
 export function JobQueueStatus({
@@ -23,6 +25,7 @@ export function JobQueueStatus({
   detail,
   progressClassName,
   containerClassName,
+  queueIncludesRunning = true,
 }: JobQueueStatusProps) {
   const { state } = useWorkspace();
   const [elapsed, setElapsed] = useState('0s');
@@ -43,11 +46,17 @@ export function JobQueueStatus({
   if (!runningId) return null;
 
   const currentJob = state.jobs.find((job) => job.id === runningId);
-  const resolvedTotal = Math.max(total, queue.length, 1);
-  const queuedCount = queue.length;
-  const currentPosition = Math.min(resolvedTotal, resolvedTotal - queuedCount + 1);
-  const queuedAfterCurrent = Math.max(queue.length - 1, 0);
-  const progress = Math.max(0, Math.min(100, (currentPosition / resolvedTotal) * 100));
+  const {
+    resolvedTotal,
+    currentPosition,
+    queuedAfterCurrent,
+    progress,
+  } = getQueueProgress({
+    queue,
+    total,
+    hasRunning: Boolean(runningId),
+    queueIncludesRunning,
+  });
 
   return (
     <div className={containerClassName}>

--- a/web/src/features/workspace/TailoringStatus.tsx
+++ b/web/src/features/workspace/TailoringStatus.tsx
@@ -14,6 +14,7 @@ export function TailoringStatus() {
       detail="generating resume, cover letter, scorecard, and keyword gap"
       containerClassName="border-b border-border bg-primary/5 px-4 py-2 shrink-0"
       progressClassName="mt-2 h-1.5 bg-primary/15"
+      queueIncludesRunning={false}
     />
   );
 }

--- a/web/src/lib/queues.ts
+++ b/web/src/lib/queues.ts
@@ -11,6 +11,20 @@ export interface AppendJobIdsResult {
   added: string[];
 }
 
+export interface QueueProgressOptions {
+  queue: string[];
+  total: number;
+  hasRunning: boolean;
+  queueIncludesRunning?: boolean;
+}
+
+export interface QueueProgressResult {
+  resolvedTotal: number;
+  currentPosition: number;
+  queuedAfterCurrent: number;
+  progress: number;
+}
+
 export function appendUniqueJobIdsToQueue({
   queue,
   runningId,
@@ -39,5 +53,33 @@ export function appendUniqueJobIdsToQueue({
     queue: nextQueue,
     total: Math.max(total, activeCount) + added.length,
     added,
+  };
+}
+
+export function getQueueProgress({
+  queue,
+  total,
+  hasRunning,
+  queueIncludesRunning = true,
+}: QueueProgressOptions): QueueProgressResult {
+  const activeCount = queue.length + (hasRunning && !queueIncludesRunning ? 1 : 0);
+  const resolvedTotal = Math.max(total, activeCount, hasRunning ? 1 : 0);
+  const remainingIncludingCurrent = hasRunning ? activeCount : 0;
+  const currentPosition = hasRunning
+    ? Math.max(1, resolvedTotal - remainingIncludingCurrent + 1)
+    : 0;
+  const queuedAfterCurrent = Math.max(
+    queueIncludesRunning ? queue.length - (hasRunning ? 1 : 0) : queue.length,
+    0,
+  );
+  const progress = hasRunning && resolvedTotal > 0
+    ? Math.max(0, Math.min(100, (currentPosition / resolvedTotal) * 100))
+    : 0;
+
+  return {
+    resolvedTotal,
+    currentPosition,
+    queuedAfterCurrent,
+    progress,
   };
 }

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -323,7 +323,7 @@ export function reducer(state: WorkspaceState, action: Action): WorkspaceState {
         ...state,
         tailorQueue: action.queue,
         tailorQueueTotal:
-          action.queue.length === 0
+          action.queue.length === 0 && state.tailorRunning === null
             ? 0
             : action.total ?? state.tailorQueueTotal,
       };
@@ -334,6 +334,10 @@ export function reducer(state: WorkspaceState, action: Action): WorkspaceState {
         tailorRunning: action.id,
         tailorRunningStartedAt:
           action.id == null ? 0 : action.startedAt ?? Date.now(),
+        tailorQueueTotal:
+          action.id == null && state.tailorQueue.length === 0
+            ? 0
+            : state.tailorQueueTotal,
       };
 
     case 'SET_TAILOR_SUMMARY':


### PR DESCRIPTION
## Summary
- Fix resume export background variable
- Correct tailor queue progress: extract `getQueueProgress()` helper with `queueIncludesRunning` flag so the tailor queue (which excludes the running job) reports correct position/total, including the final "N of N" state while the last job is still running
- Preserve `tailorQueueTotal` while a job is running even after the queue array empties; reset to 0 only once both are clear
- Replace two-line path/status in SourcesPanel with a single `getSourceStatusLabel()` that distinguishes "Saved in workspace" vs "Unsaved in editor" for in-memory documents

## Test plan
- [ ] `npm test`
- [ ] `npm run typecheck`
- [ ] Manually: queue 3+ jobs, confirm progress shows "1 of 3 → 2 of 3 → 3 of 3" and bar hits 100% while the last tailor is still finishing
- [ ] Manually: load a source from disk, edit in place, save workspace; confirm status transitions Loaded from path → Unsaved in editor → Saved in workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced source status display to show whether items are loaded from file, saved in workspace, or unsaved in editor.
  * Improved tailor queue progress tracking with better handling of running and queued jobs.

* **Bug Fixes**
  * Fixed queue state management to correctly track tailor queue totals when jobs are running.

* **Tests**
  * Added comprehensive test coverage for queue progress, source status, and workspace state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->